### PR TITLE
Retire window_start_delay; add pdf-in/careful/ folder convention and interface: config block

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,20 +93,31 @@ absent from disk is an error at startup, not a warning.
 | Key                     | Default             | Effect                                                                                                            |
 | ----------------------- | ------------------- | ----------------------------------------------------------------------------------------------------------------- |
 | `model`                 | `claude-sonnet-4-6` | Price alternatives with `dev/estimate_cost.py --model <id>` first.                                                |
+| `careful_model`         | `claude-opus-5`     | Used automatically for sources in `pdf-in/careful/` during `--all`. See Usage.                                    |
 | `max_tokens`            | `4000`              | Ceiling per response; entries run 400–500 tokens.                                                                 |
 | `cache_ttl`             | `"1h"`              | Prompt-cache lifetime. Cheaper unless runs are genuinely isolated.                                                |
 | `enrich_missing_fields` | `true`              | The CrossRef/Scholar lookups, the grounding audit and reconciliation. `false` leaves only the initial extraction. |
 | `verbose`               | `true`              | Progress on stderr.                                                                                               |
-| `show_window`           | `false`             | The floating progress window; `--window`/`--no-window` override.                                                  |
-| `window_models`         | sonnet-4-6, opus-5  | Models offered in the window's dropdown. Unset hides it.                                                          |
-| `window_start_delay`    | `4`                 | Seconds before the first file, during which the model may be changed.                                             |
-| `notifications`         | `false`             | macOS notifications for batch progress and failures.                                                              |
 | `ocr_threshold`         | `100`               | Words below which a PDF is treated as scanned.                                                                    |
 | `ocr_timeout`           | `180`               | Seconds allowed to `ocrmypdf`.                                                                                    |
 | `default_ocr_language`  | `eng`               | Tesseract language when OCR runs unattended.                                                                      |
 | `autofile_bibdesk`      | `false`             | Import into BibDesk directly rather than to the staging file.                                                     |
 | `crossref_email`        | —                   | Opts into CrossRef's faster polite pool. Free, no account.                                                        |
 | `scrapingdog_api_key`   | —                   | Enables the Google Scholar fallback. Paid, roughly a fifth of a cent per lookup.                                  |
+
+Presentation settings — nothing below affects extraction — live under one
+`interface:` block:
+
+```yaml
+interface:
+  show_window: false     # The floating progress window; --window/--no-window override.
+  window_models: [...]   # Models offered in the window's dropdown. Unset hides it.
+  notifications: false   # macOS notifications for batch progress and failures.
+```
+
+A bare top-level `show_window`, `window_models` or `notifications` key (the pre-9
+layout) is still read for one release if `interface:` is absent or omits it, with a
+one-time deprecation warning on stderr; move it under `interface:` when convenient.
 
 The remaining paths — `pdf_in_folder`, `pdf_out_folder`, `template_file`,
 `claude_md_file`, `ref_file`, `example_files` — name the files constituting the
@@ -123,9 +134,11 @@ Right-click a PDF or `.webloc` file in Finder — or a mixed selection — and c
 **Extract BibLaTeX-Chicago Bibliography (via Claude)**.
 
 The progress window offers a **Model** dropdown listing whatever `window_models`
-names, and holds for `window_start_delay` seconds before the first file so the
-choice can be changed. Reference works (Grove, the Stanford Encyclopedia,
-Wikipedia) are where the stronger model repays its cost; see the operator note in
+names; a change there applies from the next file onward. Reference works (Grove,
+the Stanford Encyclopedia, Wikipedia) are where the stronger model repays its
+cost — rather than reaching for the dropdown in time, drop such sources into
+`pdf-in/careful/` before an `--all` run and they process with `careful_model`
+automatically, in either windowed or headless mode. See the operator note in
 `CLAUDE.md`.
 
 From the command line:
@@ -278,6 +291,7 @@ ostracon-ai/
 ├── automator/
 │   └── script.sh.example   # Copy to script.sh; set PYTHON and WORKDIR
 ├── pdf-in/                 # Sources for --all
+│   └── careful/            # Same, but processed with careful_model
 └── pdf-out/                # Where they go afterwards
 ```
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -33,28 +33,19 @@ ocr_timeout: 180 # Seconds to allow ocrmypdf on the extracted page subset before
 max_tokens: 4000 # Maximum tokens for Claude response
 model: "claude-sonnet-4-20250514" # Claude model to use
 
+# Model used automatically for source files placed in pdf-in/careful/ during
+# an --all run, instead of `model` above. Replaces having to notice a
+# reference-work source (Grove, the Stanford Encyclopedia, Wikipedia) and
+# react in time to change a dropdown: drop the file in the subfolder instead.
+# See the operator note in CLAUDE.md.
+careful_model: "claude-opus-5"
+
 # Prompt cache TTL for the shared static context. "1h" costs 2x base input to
 # write (vs 1.25x for the 5-minute default) but survives between separate
 # Quick Action invocations, which is the cheaper trade unless you always
 # process files in one large batch. Set to "5m" for the short tier, or to an
 # empty value to use the API default.
 cache_ttl: "1h"
-
-# Models offered in the progress window's dropdown, so the Finder Quick Action
-# can reach a stronger model without a command line. The first entry is only a
-# default if `model` above is absent from the list. Switching mid-batch applies
-# from the next file and is inexpensive - prompt caches are per-model and
-# coexist, so a run that alternates pays one cache write per model, not one per
-# switch. See the README's Cost Estimate section.
-window_models:
-  - "claude-sonnet-4-6"
-  - "claude-opus-5"
-
-# Seconds the progress window waits before the first file, so the model
-# dropdown can be changed for a batch you already know needs a stronger model.
-# The run starts on its own when the count expires - an unattended batch is
-# never left waiting. Set to 0 to start immediately.
-window_start_delay: 4
 default_ocr_language: "eng"  # Tesseract language code used in quiet/automation mode (eng, rus, deu, fra, etc.)
 
 # Enrichment: fill in fields the PDF itself doesn't contain (volume, issue,
@@ -67,8 +58,22 @@ scrapingdog_api_key: "" # Optional: ScrapingDog API key for Google Scholar fallb
 
 # Logging
 verbose: true
-notifications: false  # Send macOS notifications (batch progress updates and validation failures)
-show_window: false  # Show floating progress window (overridden by --window / --no-window flags)
+
+# Presentation only - none of this affects extraction. A top-level key of the
+# same name (show_window, window_models, notifications) is still read for one
+# release, with a deprecation warning, if this block is absent or omits it.
+interface:
+  show_window: false  # Floating progress window (overridden by --window / --no-window flags)
+  # Models offered in the progress window's dropdown, so the Finder Quick
+  # Action can reach a stronger model without a command line. The first entry
+  # is only a default if `model` above is absent from the list. Switching
+  # mid-batch applies from the next file and is inexpensive - prompt caches
+  # are per-model and coexist, so a run that alternates pays one cache write
+  # per model, not one per switch. See the README's Cost Estimate section.
+  window_models:
+    - "claude-sonnet-4-6"
+    - "claude-opus-5"
+  notifications: false  # Send macOS notifications (batch progress updates and validation failures)
 
 # BibDesk integration
 autofile_bibdesk: false  # After saving each entry, import it into BibDesk and auto-file the linked PDF.

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -51,6 +51,21 @@ def glob_input_files(folder):
     )
 
 
+# Model used for sources placed in pdf-in/careful/ when config.yaml sets no
+# careful_model of its own - see the reference-work operator note in CLAUDE.md.
+DEFAULT_CAREFUL_MODEL = "claude-opus-5"
+
+
+def glob_batch_files(folder):
+    """Source files for an --all run: folder itself plus its careful/
+    subfolder, if present (see process_batch's folder-convention note)."""
+    files = glob_input_files(folder)
+    careful_dir = Path(folder) / 'careful'
+    if careful_dir.is_dir():
+        files += glob_input_files(careful_dir)
+    return sorted(files)
+
+
 # Config paths are written relative to the repository ("./CLAUDE.md"), so they
 # must resolve against it rather than against the working directory - otherwise
 # the tool only runs from the repo root, and the Automator wrapper's `cd
@@ -90,6 +105,32 @@ def response_text(message):
     access a migration tripwire rather than a theoretical one.
     """
     return "".join(b.text for b in message.content if b.type == "text")
+
+
+# show_window, window_models and notifications govern presentation only and
+# moved under a single `interface:` config block. The bare top-level key of
+# the same name is still honored for one release (warns once via stderr) so
+# an existing config.yaml keeps working; see README.
+_deprecated_interface_keys_warned = set()
+
+
+def _interface_setting(config, key, default=None):
+    """Look up a presentation-only setting, preferring config['interface']
+    over the deprecated top-level key of the same name."""
+    interface = config.get('interface') or {}
+    if key in interface:
+        return interface[key]
+    if key in config:
+        if key not in _deprecated_interface_keys_warned:
+            _deprecated_interface_keys_warned.add(key)
+            print(
+                f"⚠ config key '{key}' is deprecated; move it under 'interface:' "
+                f"(see README). The top-level key will stop being read in the "
+                f"next release.",
+                file=sys.stderr,
+            )
+        return config[key]
+    return default
 
 
 class BiblioAgent:
@@ -477,13 +518,15 @@ excerpt's text won't (e.g. an embedded Author field):
             ocr_timeout=self.config.get('ocr_timeout', 180),
         )
 
-    def extract_bibtex(self, path, batch_info=None):
+    def extract_bibtex(self, path, batch_info=None, model_override=None):
         """
         Extract bibliographic information from a source file (PDF or .webloc).
 
         Args:
             path: Path to the source file
             batch_info: Optional (current_index, total) tuple for batch progress display
+            model_override: Use this model for this call only, instead of
+                config['model'] - for pdf-in/careful/ sources (see process_batch).
 
         Returns:
             str: BibLaTeX entry or error message
@@ -527,11 +570,15 @@ excerpt's text won't (e.g. an embedded Author field):
         prompt = self.build_prompt(content)
 
         # Call Claude API
-        self._log("   Sending to Claude...", 'info')
+        model = model_override or self.config['model']
+        if model_override:
+            self._log(f"   Sending to Claude ({model}, careful)...", 'info')
+        else:
+            self._log("   Sending to Claude...", 'info')
 
         try:
             message = self.client.messages.create(
-                model=self.config['model'],
+                model=model,
                 max_tokens=self.config['max_tokens'],
                 messages=[
                     {"role": "user", "content": self._cached_message_content(context, prompt)}
@@ -1063,7 +1110,7 @@ end tell'''
 
     def notify_progress(self, message, subtitle=""):
         """Send a macOS notification for progress updates (when notifications are enabled)."""
-        if not self.config.get('notifications', True):
+        if not _interface_setting(self.config, 'notifications', True):
             return
         script = f'display notification "{message}" with title "Ostracon AI"'
         if subtitle:
@@ -1072,7 +1119,7 @@ end tell'''
 
     def notify_incomplete(self, pdf_name, missing_fields):
         """Send a macOS notification that an entry was saved but is missing fields."""
-        if not self.config.get('notifications', True):
+        if not _interface_setting(self.config, 'notifications', True):
             return
         msg = f"{pdf_name}: saved but missing {', '.join(missing_fields)}."
         subprocess.run(
@@ -1083,7 +1130,7 @@ end tell'''
 
     def notify_failure(self, pdf_name, error_msg):
         """Send a macOS notification about a validation failure."""
-        if not self.config.get('notifications', True):
+        if not _interface_setting(self.config, 'notifications', True):
             return
         failed_path = Path(self.config.get('failed_bib_file', '~/Desktop/biblio-failed.bib')).expanduser()
         msg = f"Brace validation failed for {pdf_name}: {error_msg}. Entry saved to {failed_path}."
@@ -1270,6 +1317,11 @@ end tell'''
         Process a list of source files (or all supported files in the input
         folder when pdf_files is None).
 
+        Sources placed in pdf_in_folder/careful/ are processed with
+        careful_model instead of model - the folder is a deliberate gesture
+        (dropping a reference-work source there) rather than a choice made
+        under time pressure in a dropdown.
+
         Args:
             move_files: If True, move processed files to output folder
             pdf_files: Explicit list of Path objects; falls back to pdf_in_folder if None
@@ -1278,15 +1330,15 @@ end tell'''
         Returns:
             dict: Summary with 'success', 'failed', 'skipped' lists
         """
+        in_folder = Path(self.config.get('pdf_in_folder', './pdf-in'))
         if pdf_files is not None:
             files = [Path(p) for p in pdf_files]
         else:
-            in_folder = Path(self.config.get('pdf_in_folder', './pdf-in'))
             if not in_folder.exists():
                 self._log(f"Error: Input folder not found: {in_folder}", 'error')
                 self._log(f"Create it with: mkdir {in_folder}", 'error')
                 return {'success': [], 'failed': [], 'skipped': []}
-            files = glob_input_files(in_folder)
+            files = glob_batch_files(in_folder)
 
         if not files:
             self._log("No source files found.", 'warning')
@@ -1300,6 +1352,7 @@ end tell'''
             self._save_bibdesk_document()
 
         results = {'success': [], 'failed': [], 'skipped': []}
+        careful_dir = (in_folder / 'careful').resolve()
 
         for i, pdf_path in enumerate(files, 1):
             if progress_window and progress_window.cancelled:
@@ -1316,10 +1369,16 @@ end tell'''
                 if chosen and chosen != self.config['model']:
                     self.config['model'] = chosen
 
+            # A file from pdf_in_folder/careful/ always takes careful_model,
+            # regardless of the dropdown above - the point of the folder is
+            # to not depend on the operator noticing and reacting in time.
+            is_careful = pdf_path.resolve().parent == careful_dir
+            model_for_file = self.config.get('careful_model', DEFAULT_CAREFUL_MODEL) if is_careful else None
+
             self.notify_progress(f"[{i}/{total}] {pdf_path.name}", subtitle="Extracting bibliography")
 
             # Extract bibliography
-            bibtex_entry = self.extract_bibtex(pdf_path, batch_info=(i, total))
+            bibtex_entry = self.extract_bibtex(pdf_path, batch_info=(i, total), model_override=model_for_file)
 
             if bibtex_entry.startswith("Error:"):
                 self._log(f"   ✗ {bibtex_entry}", 'error')
@@ -1371,7 +1430,7 @@ def _resolve_show_window(args, config):
         return False
     if args.window is not None:
         return args.window  # --window or --no-window explicitly set
-    return config.get('show_window', False)
+    return _interface_setting(config, 'show_window', False)
 
 
 def _run_windowed(agent, pdf_files, move_files):
@@ -1385,21 +1444,14 @@ def _run_windowed(agent, pdf_files, move_files):
 
     win = ProgressWindow(
         total_files=len(pdf_files),
-        models=agent.config.get('window_models') or [agent.config['model']],
+        models=_interface_setting(agent.config, 'window_models', None) or [agent.config['model']],
         current_model=agent.config['model'],
     )
     agent._progress_callback = win.make_callback()
     win.show()
 
     def _process():
-        # Hold briefly before the first file. The batch loop re-reads the model
-        # popup each iteration, but without this the first file would already
-        # be in flight before the window was usable, so a batch you know needs
-        # a stronger model could not get one until file two.
-        delay = agent.config.get('window_start_delay') or 0
-        if delay:
-            win.countdown(delay)
-        if win.cancelled:
+        if win.cancelled:  # window closed before the worker thread got going
             win.finish(had_error=False)
             return
 
@@ -1505,7 +1557,7 @@ def main():
         if args.all:
             if show_window:
                 in_folder = Path(agent.config.get('pdf_in_folder', './pdf-in'))
-                pdf_files = glob_input_files(in_folder)
+                pdf_files = glob_batch_files(in_folder)
                 _run_windowed(agent, pdf_files, move_files=not args.no_move)
             else:
                 results = agent.process_batch(move_files=not args.no_move)

--- a/src/progress_window.py
+++ b/src/progress_window.py
@@ -277,21 +277,6 @@ class ProgressWindow:
 
         _on_main(_update)
 
-    def countdown(self, seconds: int) -> None:
-        """Hold before the first file, so the model can still be changed.
-
-        Called from the worker thread: it blocks there while the main thread
-        keeps running the event loop, which is what leaves the popup live. The
-        run starts on its own when the count expires, so an unattended batch is
-        never stranded waiting for a click.
-        """
-        for remaining in range(int(seconds), 0, -1):
-            if self.cancelled:
-                return
-            plural = "" if remaining == 1 else "s"
-            self._set_header(f"Starting in {remaining} second{plural} \u2014 change model now")
-            time.sleep(1)
-
     def set_progress(self, current: int, filename: str) -> None:
         """Update the header progress line. Thread-safe."""
         total = self._total


### PR DESCRIPTION
Closes #9

## Summary

- Deleted `window_start_delay` and `ProgressWindow.countdown()`. The window's model dropdown still re-reads live each iteration; only the four-second race is gone.
- Implemented the folder-convention option: files placed in `pdf-in/careful/` are processed with the new `careful_model` config key (default `claude-opus-5`) instead of `model`, during `--all` in both windowed and headless mode. `glob_batch_files()` collects both the top-level folder and `careful/`; `process_batch()` resolves the override per file by the source's own directory; `extract_bibtex()` takes an optional `model_override`.
- Collapsed `show_window`, `window_models` and `notifications` into a single `interface:` config block. A bare top-level key of the same name is still honored for one release via `_interface_setting()`, with a one-time stderr deprecation warning, so an existing `config.yaml` keeps working unmodified.

## Testing

No live Anthropic calls were made. `python dev/test_setup.py` passes (installed the project's `requirements.txt` into a throwaway venv, since none of `anthropic`/`pyyaml`/etc. are present globally here).

Additionally exercised end-to-end with a stubbed `Anthropic` client and a fake PDF extractor (not part of the repo, run ad hoc):
- `glob_batch_files()` picks up both `pdf-in/*.pdf` and `pdf-in/careful/*.pdf`.
- A batch with one file in each location calls the stub with `claude-opus-5` for the `careful/` file and the configured `model` for the other, and both succeed and move to `pdf_out_folder`.
- An old-style config (flat `show_window`/`window_models`/`notifications`, no `interface:` block, no `careful_model`) still loads, warns once per deprecated key on stderr, resolves `show_window` correctly, and falls back to `DEFAULT_CAREFUL_MODEL` when `careful_model` is unset.

`config.yaml`, `CLAUDE.md`, `notes-test.bib` and the rest of the cached prompt prefix are untouched.

## Decisions

Per the issue's "pick one," went with the folder convention (`pdf-in/careful/`) over classify-by-rule or two separate Quick Actions - least invasive, no new Automator wiring, and it doesn't try to guess a source's kind from its URL or first page the way "classify" would.

- **`careful_model` is a plain top-level key, not nested under `interface:`.** It's a processing decision (which model extracts a given file), not a presentation setting - `interface:` is reserved for the show_window/window_models/notifications kind of thing.
- **Default `careful_model` is `claude-opus-5`**, matching the existing operator note in `CLAUDE.md` about reference works. Alternative considered: no default, require the key - rejected as needlessly brittle for a config predating this feature.
- **The careful override is detected by the file's actual parent directory**, not by which code path assembled the file list. This is what makes it work uniformly for `--all` (headless), `--all --window`, and even an explicit CLI path that happens to name a file inside `pdf-in/careful/` - one rule instead of three. Alternative considered: gate it strictly to the implicit-glob branch of `process_batch`, which would have silently missed the windowed `--all` path, since `main()` pre-globs the file list before calling `process_batch` in that branch.
- **The window's model dropdown (`window_models`) is kept, not removed.** The issue's three proposals were alternatives for reaching a stronger model without noticing the file type in time; only the countdown was the actual problem. The dropdown itself remains a legitimate manual override, now simply redundant rather than load-bearing for reference-work sources.
- **Old flat `show_window`/`window_models`/`notifications` keys are deprecated with a warning, not removed**, per the "one release" instruction. `window_start_delay` itself is deleted outright rather than deprecated, since the issue asks to remove it entirely rather than migrate it.
- **`config.yaml` (the real, gitignored local config) was left untouched.** Backward compatibility means it keeps working as-is; editing a live file carrying a real API key felt like the wrong thing to do without being asked.
