### PR TITLE
Add browser DOM capture as a bot-challenge fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,9 +44,12 @@ leaves the entry amber in BibDesk.
 
 Some publishers — Oxford Academic and other Silverchair platforms among them — front every page
 with a Cloudflare bot challenge that no HTTP client can pass, so a `.webloc` pointing at one
-cannot be fetched at all. Where the bookmarked URL carries a DOI in its path, the entry is built
-from the CrossRef record instead. Any other fetch failure is still reported rather than papered
-over, so a dead bookmark stays visible as one.
+cannot be fetched at all. Two fallbacks apply, in order: if the bookmarked URL happens to still
+be open in a Safari or Chrome tab, the page's DOM is read from there instead of fetched again -
+a browser already holds the session cookie and a genuine TLS fingerprint, which is what the
+challenge actually checks (see Troubleshooting). Failing that, if the URL carries a DOI in its
+path, the entry is built from the CrossRef record instead. Any other fetch failure is still
+reported rather than papered over, so a dead bookmark stays visible as one.
 
 ![Progress window](screenshot.png)
 
@@ -287,6 +290,13 @@ Settings ▸ Keyboard ▸ Keyboard Shortcuts ▸ Services ▸ Files and Folders.
 `claude_md_file`, `template_file`, `ref_file` or `example_files` is not where the
 configuration says. These constitute the cached prefix, so the agent refuses to
 start rather than proceed without them.
+
+**A bot-challenged `.webloc` fails even with the page open in a tab.** The browser DOM
+fallback needs a one-time permission: in Safari, Develop ▸ Allow JavaScript from Apple
+Events (enable the Develop menu first under Settings ▸ Advanced, if it isn't visible);
+in Chrome, View ▸ Developer ▸ Allow JavaScript from Apple Events. Without it, capture
+silently fails exactly as if no tab had matched, and the CrossRef fallback (or the
+plain error) takes over instead.
 
 **OCR not running.** Install `ocrmypdf`. Without it the agent falls back to direct
 extraction.

--- a/README.md
+++ b/README.md
@@ -44,12 +44,18 @@ leaves the entry amber in BibDesk.
 
 Some publishers — Oxford Academic and other Silverchair platforms among them — front every page
 with a Cloudflare bot challenge that no HTTP client can pass, so a `.webloc` pointing at one
-cannot be fetched at all. Two fallbacks apply, in order: if the bookmarked URL happens to still
-be open in a Safari or Chrome tab, the page's DOM is read from there instead of fetched again -
-a browser already holds the session cookie and a genuine TLS fingerprint, which is what the
-challenge actually checks (see Troubleshooting). Failing that, if the URL carries a DOI in its
-path, the entry is built from the CrossRef record instead. Any other fetch failure is still
-reported rather than papered over, so a dead bookmark stays visible as one.
+cannot be fetched at all; others (login walls, consent gates, DataDome/Kasada) answer a plain
+HTTP 200 with an interstitial instead, which arrives looking exactly like a real page. Every
+page - fetched, read from a browser tab, or built from CrossRef - is checked for plausibility
+before it's trusted: the metadata has to identify a work, and the content has to correspond to
+the URL requested, or it's discarded and the next source is tried rather than handed to Claude
+as if it were the article. If the bookmarked URL happens to still be open in a Safari or Chrome
+tab, the page's DOM is read from there instead of fetched again - a browser already holds the
+session cookie and a genuine TLS fingerprint, which is what a Cloudflare challenge actually
+checks (see Troubleshooting) - tried on any fetch failure, not only a Cloudflare one. Failing
+that, if the fetch hit a classified bot challenge and the URL carries a DOI in its path, the
+entry is built from the CrossRef record instead. Any other fetch failure is still reported
+rather than papered over, so a dead bookmark stays visible as one.
 
 ![Progress window](screenshot.png)
 
@@ -79,6 +85,10 @@ availability, and confirms the documentation still names every configuration key
 every command-line flag and every tracked file. The quick action runs
 `dev/test_setup.py --preflight` before each batch: silent when all is well, and
 abandoning the run with a message when it is not.
+
+`python3 dev/test_web_source.py` self-tests `web_source.py`'s fetch/browser-tab/CrossRef
+fallback and plausibility check against canned fixtures - the live failures it guards
+against (an actual bot challenge, a half-loaded tab) can't be staged by hand.
 
 ## Configuration
 

--- a/README.md
+++ b/README.md
@@ -47,15 +47,19 @@ with a Cloudflare bot challenge that no HTTP client can pass, so a `.webloc` poi
 cannot be fetched at all; others (login walls, consent gates, DataDome/Kasada) answer a plain
 HTTP 200 with an interstitial instead, which arrives looking exactly like a real page. Every
 page - fetched, read from a browser tab, or built from CrossRef - is checked for plausibility
-before it's trusted: the metadata has to identify a work, and the content has to correspond to
-the URL requested, or it's discarded and the next source is tried rather than handed to Claude
-as if it were the article. If the bookmarked URL happens to still be open in a Safari or Chrome
-tab, the page's DOM is read from there instead of fetched again - a browser already holds the
-session cookie and a genuine TLS fingerprint, which is what a Cloudflare challenge actually
-checks (see Troubleshooting) - tried on any fetch failure, not only a Cloudflare one. Failing
-that, if the fetch hit a classified bot challenge and the URL carries a DOI in its path, the
-entry is built from the CrossRef record instead. Any other fetch failure is still reported
-rather than papered over, so a dead bookmark stays visible as one.
+before it's trusted. Only one thing there is treated as a failure: the content doesn't
+correspond to the URL requested (a login wall, a captured tab that's navigated elsewhere) -
+that's the wrong document, and the next source is tried rather than handing Claude a confident
+wrong entry. A source that's merely thin - no Author, Doi or PublicationDate beyond an
+access-date `Urldate`, or a short body - still produces an entry, marked amber for a glance
+rather than discarded: this project's library carries plenty of real `@Online` sources (a
+personal page, a manufacturer's spec sheet) with a title and nothing else, for which `Urldate`
+is the ordinary dating evidence, not a defect. If the bookmarked URL happens to still be open
+in a Safari or Chrome tab, the page's DOM is read from there instead of fetched again - a
+browser already holds the session cookie and a genuine TLS fingerprint, which is what a
+Cloudflare challenge actually checks (see Troubleshooting) - tried on any fetch failure, not
+only a Cloudflare one. Failing that, if the fetch hit a classified bot challenge and the URL
+carries a DOI in its path, the entry is built from the CrossRef record instead.
 
 ![Progress window](screenshot.png)
 
@@ -87,8 +91,13 @@ every command-line flag and every tracked file. The quick action runs
 abandoning the run with a message when it is not.
 
 `python3 dev/test_web_source.py` self-tests `web_source.py`'s fetch/browser-tab/CrossRef
-fallback and plausibility check against canned fixtures - the live failures it guards
-against (an actual bot challenge, a half-loaded tab) can't be staged by hand.
+fallback and plausibility check (including the amber-vs-fail split) against canned
+fixtures - the live failures it guards against (an actual bot challenge, a half-loaded
+tab) can't be staged by hand.
+
+`python3 dev/test_biblio_agent_markers.py` self-tests `save_entry()`'s marker
+extraction/reattachment - in particular that the `% AMBER: ...` comment a thin/sparse
+`.webloc` source needs (see above) actually survives into the saved `.bib` text.
 
 ## Configuration
 

--- a/dev/test_biblio_agent_markers.py
+++ b/dev/test_biblio_agent_markers.py
@@ -35,11 +35,24 @@ sys.path.insert(0, str(ROOT / "src"))
 import biblio_agent  # noqa: E402
 
 
-def _agent(tmp_bib_path):
+def _agent(tmp_bib_path, autofile=False):
     agent = biblio_agent.BiblioAgent(str(ROOT / "config.yaml"))
     agent.config["main_bib_file"] = str(tmp_bib_path)
-    agent.config["autofile_bibdesk"] = False
+    agent.config["autofile_bibdesk"] = autofile
     return agent
+
+
+def _capture_bibdesk(agent):
+    """Replace _save_via_bibdesk with a recorder - no osascript, no BibDesk,
+    nothing launched. Returns the dict the call's kwargs land in."""
+    calls = {}
+
+    def _fake(entry, bib_path, needs_color=False, auto_file=True):
+        calls.update(entry=entry, bib_path=bib_path,
+                     needs_color=needs_color, auto_file=auto_file)
+
+    agent._save_via_bibdesk = _fake
+    return calls
 
 
 def test_source_and_amber_comments_survive_needs_color_flag_is_discarded():
@@ -100,9 +113,87 @@ def test_entry_without_amber_marker_is_unaffected():
     return True
 
 
+def test_webloc_reaches_bibdesk_and_is_colored_without_auto_file():
+    # The whole point of the routing fix: under autofile_bibdesk the importer
+    # discards every % comment, so the color is the ONLY surviving carrier of
+    # the amber flag - and a .webloc entry used to be excluded from the import
+    # path entirely, so it got neither. It must now be imported and colored,
+    # with only `auto file` withheld (there is no document to file).
+    entry_text = (
+        "% Source: webpage (https://example.org/x)\n"
+        "% NEEDS_COLOR_FLAG\n"
+        "% AMBER: no Author/Doi/PublicationDate - only Urldate available to date it\n"
+        "@Online{WeblocTest2026,\n  Title = {A Study of Musical Form},\n}\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        agent = _agent(bib_path, autofile=True)
+        calls = _capture_bibdesk(agent)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            ok = agent.save_entry(entry_text, "smoketest.webloc")
+
+    assert ok is True
+    assert calls, "a .webloc entry never reached _save_via_bibdesk"
+    assert calls["needs_color"] is True, calls
+    assert calls["auto_file"] is False, calls
+    # No document, so no file bookmark should have been attached either.
+    assert "bdsk-file-1" not in calls["entry"], calls["entry"]
+    return True
+
+
+def test_pdf_still_auto_files():
+    # The other side of the same split: a PDF has a document, so auto_file
+    # stays on. Guards against "fix the .webloc case, silently stop filing
+    # every PDF."
+    entry_text = (
+        "% Source: PDF (paper.pdf)\n"
+        "% NEEDS_COLOR_FLAG\n"
+        "@Article{PdfTest2026,\n  Title = {An Ordinary Article},\n  Author = {Doe, Jane},\n}\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        agent = _agent(bib_path, autofile=True)
+        calls = _capture_bibdesk(agent)
+        # add_bdsk_bookmark would try to bookmark a file that isn't there;
+        # the bookmark itself isn't what this test is about.
+        agent.add_bdsk_bookmark = lambda entry, path: entry
+        err = io.StringIO()
+        with redirect_stderr(err):
+            ok = agent.save_entry(entry_text, "paper.pdf")
+
+    assert ok is True
+    assert calls["auto_file"] is True, calls
+    assert calls["needs_color"] is True, calls
+    return True
+
+
+def test_no_color_flag_means_no_color():
+    # needs_color must not become sticky: an entry carrying no
+    # NEEDS_COLOR_FLAG has to reach BibDesk uncolored.
+    entry_text = (
+        "% Source: webpage (https://example.org/x)\n"
+        "@Online{CleanTest2026,\n  Title = {A Study of Musical Form},\n}\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        agent = _agent(bib_path, autofile=True)
+        calls = _capture_bibdesk(agent)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            ok = agent.save_entry(entry_text, "clean.webloc")
+
+    assert ok is True
+    assert calls["needs_color"] is False, calls
+    return True
+
+
 TESTS = [
     test_source_and_amber_comments_survive_needs_color_flag_is_discarded,
     test_entry_without_amber_marker_is_unaffected,
+    test_webloc_reaches_bibdesk_and_is_colored_without_auto_file,
+    test_pdf_still_auto_files,
+    test_no_color_flag_means_no_color,
 ]
 
 

--- a/dev/test_biblio_agent_markers.py
+++ b/dev/test_biblio_agent_markers.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+Regression test for BiblioAgent.save_entry()'s marker extraction/reattachment
+- specifically the "% AMBER: ..." comment web_source.py's content-plausibility
+follow-up relies on to survive into the saved .bib text for a .webloc source
+(never fileable, so it never reaches BibDesk's own color - see save_entry).
+
+Found in passing while adding that marker: the pre-existing "% Source: ..."
+regex placed its \\b word-boundary assertion right after the literal colon
+(`Source:\\b`), which can never match (a non-word character can't start a
+word boundary against another non-word character) - so source_comment was
+always empty, and clean_bibtex()'s "strip everything before the first @"
+silently discarded the "% Source: ..." comment from every saved entry. Fixed
+alongside the new "% AMBER: ..." marker, which was written with the same
+mistake and would otherwise have failed exactly the same way, invisibly.
+
+No API call, no network: uses config.yaml as-is (BiblioAgent's __init__
+constructs an Anthropic client but never calls it here), redirected to a
+temp main_bib_file with autofile_bibdesk off, so nothing touches BibDesk.
+
+    python3 dev/test_biblio_agent_markers.py
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+import tempfile
+from contextlib import redirect_stderr
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import biblio_agent  # noqa: E402
+
+
+def _agent(tmp_bib_path):
+    agent = biblio_agent.BiblioAgent(str(ROOT / "config.yaml"))
+    agent.config["main_bib_file"] = str(tmp_bib_path)
+    agent.config["autofile_bibdesk"] = False
+    return agent
+
+
+def test_source_and_amber_comments_survive_needs_color_flag_is_discarded():
+    entry_text = (
+        "% Source: webpage (https://example.org/x)\n"
+        "% NEEDS_COLOR_FLAG\n"
+        "% AMBER: no Author/Doi/PublicationDate - only Urldate available to date it\n"
+        "@Online{MarkerTest2026,\n"
+        "  Title = {A Study of Musical Form},\n"
+        "  Urldate = {2026-08-29},\n"
+        "}\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        agent = _agent(bib_path)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            ok = agent.save_entry(entry_text, "smoketest.webloc")
+        saved = bib_path.read_text(encoding="utf-8")
+
+    assert ok is True
+    # NEEDS_COLOR_FLAG is internal bookkeeping only - must not reach the file.
+    assert "NEEDS_COLOR_FLAG" not in saved, saved
+    # Both comments that ARE meant to persist must actually be there, in the
+    # order extract_bibtex() prepends them (Source outermost, AMBER next).
+    assert saved.index("% Source:") < saved.index("% AMBER:") < saved.index("@Online"), saved
+    assert "% AMBER: no Author/Doi/PublicationDate" in saved, saved
+    assert "@Online{MarkerTest2026," in saved, saved
+    # needs_color (from the AMBER marker) can't reach BibDesk for a
+    # non-fileable source - the warning explaining why must still fire.
+    assert "color flag needs" in err.getvalue(), err.getvalue()
+    return True
+
+
+def test_entry_without_amber_marker_is_unaffected():
+    # A plain PDF-sourced entry (no AMBER marker at all) must still save
+    # correctly and keep its Source comment - the fix must not have broken
+    # the common case while fixing the broken one.
+    entry_text = (
+        "% Source: PDF (paper.pdf)\n"
+        "@Article{PlainTest2026,\n"
+        "  Title = {An Ordinary Article},\n"
+        "  Author = {Doe, Jane},\n"
+        "}\n"
+    )
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        agent = _agent(bib_path)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            ok = agent.save_entry(entry_text, "plaintest.pdf")
+        saved = bib_path.read_text(encoding="utf-8")
+
+    assert ok is True
+    assert "% Source: PDF (paper.pdf)" in saved, saved
+    assert "AMBER" not in saved, saved
+    assert "@Article{PlainTest2026," in saved, saved
+    return True
+
+
+TESTS = [
+    test_source_and_amber_comments_survive_needs_color_flag_is_discarded,
+    test_entry_without_amber_marker_is_unaffected,
+]
+
+
+def main():
+    failures = []
+    for test in TESTS:
+        try:
+            assert test() is True
+            print(f"  ✓ {test.__name__}")
+        except Exception as e:
+            failures.append((test.__name__, e))
+            print(f"  ✗ {test.__name__}: {e}")
+
+    print()
+    if failures:
+        print(f"{len(failures)}/{len(TESTS)} test(s) failed.")
+        return 1
+    print(f"All {len(TESTS)} save_entry marker self-tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -77,6 +77,18 @@ def _consent_wall_html():
     )
 
 
+def _wrong_doi_html():
+    """Otherwise-plausible content with no canonical/og:url at all, whose
+    embedded Doi names a different work - the one signal the DOI gate exists
+    to still catch, at a URL that does carry a DOI of its own."""
+    return (
+        "<html><head><title>A Study of Musical Form</title>"
+        '<meta name="citation_author" content="Doe, Jane">'
+        '<meta name="citation_doi" content="10.9999/not-the-same-doi"></head>'
+        "<body><p>" + _words(150) + "</p></body></html>"
+    )
+
+
 def _wrong_canonical_html():
     """Otherwise-plausible content whose canonical link names a different
     page entirely - no og:url or Doi present to rescue it."""
@@ -230,6 +242,21 @@ def test_browser_wrong_canonical_falls_through():
     return True
 
 
+def test_browser_wrong_doi_falls_through():
+    # The DOI gate added after the initial pass exists precisely so this
+    # case is still caught: BOOKMARK_URL carries a DOI of its own
+    # (doi_candidates() finds one), so a page declaring a *different* DOI -
+    # with no canonical/og:url to override it - is a genuine contradiction,
+    # not merely unverifiable. A captured tab that navigated to a different
+    # article entirely would look like this.
+    with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+         _browser_returns(_wrong_doi_html()), _no_crossref():
+        result, log = _run()
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "browser tab" in log and "rejected" in log, log
+    return True
+
+
 def test_no_tab_falls_back_to_crossref():
     # #11 item 4, case 6 (the DOI-fallback branch): unchanged from #8/#10.
     with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
@@ -337,6 +364,7 @@ TESTS = [
     test_browser_genuine_article_succeeds,
     test_200_interstitial_rejected,
     test_browser_wrong_canonical_falls_through,
+    test_browser_wrong_doi_falls_through,
     test_no_tab_falls_back_to_crossref,
     test_no_tab_no_doi_clean_failure_unchanged_text,
     test_non_challenge_failure_skips_crossref_unchanged_text,

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -156,12 +156,14 @@ def _fake_webloc(tmp_path_url=BOOKMARK_URL):
     return _patched(web_source, "resolve_webloc", lambda path: tmp_path_url)
 
 
-def _no_browser_tab():
-    return _patched(web_source, "browser_tab_dom", lambda url: (None, None))
+def _no_browser_tab(summary="Safari: no matching tab (3 tab(s) examined)"):
+    return _patched(web_source, "browser_tab_dom",
+                     lambda url, log=None: (None, None, summary))
 
 
 def _browser_returns(html, app="Safari"):
-    return _patched(web_source, "browser_tab_dom", lambda url: (html, app))
+    return _patched(web_source, "browser_tab_dom",
+                     lambda url, log=None: (html, app, f"{app}: match"))
 
 
 def _no_crossref():
@@ -199,6 +201,129 @@ def _run(url=BOOKMARK_URL):
         with redirect_stderr(err):
             result = web_source.extract_webloc("dummy.webloc")
         return result, err.getvalue()
+
+
+# ── browser_tab_dom: the three states, via a stubbed subprocess.run ──────
+#
+# These are the only tests that exercise browser_tab_dom itself rather than
+# stubbing it. osascript is never invoked and no browser is touched: a fake
+# subprocess.run answers each AppleScript by what it asks for.
+
+class _Osa:
+    """Canned osascript results, keyed by what the script is asking.
+
+    `tabs` is [(window, tab, url)]; `running` and the two refusal switches
+    select which of the distinguishable failures to simulate.
+    """
+
+    def __init__(self, running=True, tabs=(), refuse_events=False,
+                 refuse_js=False, capture=""):
+        self.running = running
+        self.tabs = tabs
+        self.refuse_events = refuse_events
+        self.refuse_js = refuse_js
+        self.capture = capture
+        self.scripts = []
+
+    class _R:
+        def __init__(self, returncode=0, stdout="", stderr=""):
+            self.returncode, self.stdout, self.stderr = returncode, stdout, stderr
+
+    # Wording taken from a real macOS -1743; only the numeric code is matched on.
+    _REFUSAL = ("execution error: Not authorized to send Apple events to "
+                "Safari. (-1743)")
+
+    def __call__(self, argv, capture_output=None, text=None, timeout=None):
+        script = argv[-1]
+        self.scripts.append(script)
+        if self.refuse_events:
+            return self._R(1, "", self._REFUSAL)
+        if "is running" in script:
+            return self._R(0, "true" if self.running else "false")
+        if "repeat with w in windows" in script:
+            out = "".join(f"{w}\t{t}\t{u}\n" for w, t, u in self.tabs)
+            return self._R(0, out)
+        # the JS capture
+        if self.refuse_js:
+            return self._R(1, "", self._REFUSAL)
+        return self._R(0, self.capture)
+
+
+def _osa(**kw):
+    return _patched(web_source.subprocess, "run", _Osa(**kw))
+
+
+def _probe(url=BOOKMARK_URL):
+    lines = []
+    html, app, summary = web_source.browser_tab_dom(url, log=lines.append)
+    return html, app, summary, "\n".join(lines)
+
+
+def test_browser_probe_reports_apple_events_refusal():
+    # State 1 of 3. Previously indistinguishable from "no tab" - this is the
+    # conflation that made a single failure take three rounds to diagnose.
+    with _osa(refuse_events=True):
+        html, app, summary, log = _probe()
+    assert html is None and app is None
+    assert "Apple Events refused" in summary, summary
+    assert "-1743" in summary, summary
+    assert "Apple Events refused" in log, log
+    return True
+
+
+def test_browser_probe_reports_not_running():
+    # State 2 of 3.
+    with _osa(running=False):
+        html, app, summary, log = _probe()
+    assert html is None
+    assert "not running" in summary, summary
+    assert "Apple Events refused" not in summary, summary
+    return True
+
+
+def test_browser_probe_names_the_tabs_it_saw_on_no_match():
+    # State 3 of 3, and the diagnostic that makes a matching bug visible:
+    # without the tab URLs there is no way to tell "the tab wasn't open"
+    # from "the tab was open and matching is wrong."
+    tabs = (
+        (1, 1, "https://academic.oup.com/jaac/doi/10.1093/jaac/OTHER/999?utm_source=x"),
+        (1, 2, "https://example.com/unrelated"),
+    )
+    with _osa(tabs=tabs):
+        html, app, summary, log = _probe()
+    assert html is None
+    assert "no matching tab" in summary, summary
+    # Same-host tabs are named in full, and cleaned (utm_source stripped).
+    assert "10.1093/jaac/OTHER/999" in log, log
+    assert "utm_source" not in log, log
+    assert "academic.oup.com" in log, log
+    # The off-host tab is named too, under its own heading.
+    assert "example.com/unrelated" in log, log
+    return True
+
+
+def test_browser_probe_distinguishes_js_refusal_from_missing_tab():
+    # A tab WAS found; only the separate "Allow JavaScript from Apple Events"
+    # switch refused. Reported as its own state, not as "no matching tab".
+    with _osa(tabs=((1, 1, BOOKMARK_URL),), refuse_js=True):
+        html, app, summary, log = _probe()
+    assert html is None
+    assert "JavaScript from Apple Events refused" in summary, summary
+    assert "no matching tab" not in summary, summary
+    assert "matched window 1 tab 1" in log, log
+    return True
+
+
+def test_browser_probe_captures_a_matching_tab():
+    # The success path, so the four failure tests above can't pass trivially
+    # on a probe that never works at all.
+    with _osa(tabs=((2, 3, BOOKMARK_URL + "?utm_campaign=news"),), capture="<html>ok</html>"):
+        html, app, summary, log = _probe()
+    assert html == "<html>ok</html>", html
+    assert app == "Safari"
+    assert "match" in summary, summary
+    assert "matched window 2 tab 3" in log, log
+    return True
 
 
 # ── tests ────────────────────────────────────────────────────────────────
@@ -262,7 +387,7 @@ def test_title_and_urldate_only_produces_amber():
     with _fake_webloc(), _fetch_returns(FakeResponse(text=_consent_wall_html())), \
          _crossref_raises():
         with _patched(web_source, "browser_tab_dom",
-                      lambda url: (_ for _ in ()).throw(
+                      lambda url, log=None: (_ for _ in ()).throw(
                           AssertionError("browser_tab_dom() should not have been called"))):
             result, log = _run()
     assert not isinstance(result, str), result
@@ -283,7 +408,7 @@ def test_thin_body_at_fetch_produces_amber():
     )
     with _fake_webloc(), _fetch_returns(FakeResponse(text=html)), _crossref_raises():
         with _patched(web_source, "browser_tab_dom",
-                      lambda url: (_ for _ in ()).throw(
+                      lambda url, log=None: (_ for _ in ()).throw(
                           AssertionError("browser_tab_dom() should not have been called"))):
             result, log = _run()
     assert not isinstance(result, str), result
@@ -344,25 +469,46 @@ def test_no_tab_falls_back_to_crossref():
     return True
 
 
-def test_no_tab_no_doi_clean_failure_unchanged_text():
+def test_no_tab_no_doi_failure_names_the_browser_outcome():
     # #11 item 4, case 6 (the plain-failure branch), challenge classified:
-    # no tab, no CrossRef hit - the pre-#11 error text, unchanged.
+    # no tab, no CrossRef hit. The error text deliberately NO LONGER matches
+    # the pre-#11 wording byte for byte: keeping it identical is what made a
+    # real failure indistinguishable from the old code path for three
+    # rounds. It must now name what the browser probe actually found.
     with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
-         _no_browser_tab(), _no_crossref():
+         _no_browser_tab("Safari: no matching tab (3 tab(s) examined)"), _no_crossref():
         result, log = _run()
-    assert result == (f"Error: {BOOKMARK_URL} is behind a bot challenge (HTTP 403) "
-                       f"and its URL carries no DOI to fall back on")
+    assert result.startswith(
+        f"Error: {BOOKMARK_URL} is behind a bot challenge (HTTP 403) "
+        f"and its URL carries no DOI to fall back on"), result
+    assert "browser tab: Safari: no matching tab (3 tab(s) examined)" in result, result
     assert "Source: failure for" in log, log
     return True
 
 
-def test_non_challenge_failure_skips_crossref_unchanged_text():
+def test_failure_text_distinguishes_refusal_from_absent_tab():
+    # The three states must be legible in the RETURNED text, not only in the
+    # log - the windowed run shows the returned error and little else.
+    for summary, expected in [
+        ("Safari: Apple Events refused (-1743)", "Apple Events refused"),
+        ("Safari: not running; Google Chrome: not running", "not running"),
+        ("Safari: no matching tab (12 tab(s) examined)", "no matching tab"),
+    ]:
+        with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+             _no_browser_tab(summary), _no_crossref():
+            result, _ = _run()
+        assert expected in result, (summary, result)
+    return True
+
+
+def test_non_challenge_failure_skips_crossref():
     # A plain 404 never satisfies is_bot_challenge, so crossref_fallback()
     # must never even be called for it - the original gate, preserved.
     with _fake_webloc(), _fetch_returns(PLAIN_404()), \
          _no_browser_tab(), _crossref_raises():
         result, log = _run()
-    assert result == f"Error: Could not fetch {BOOKMARK_URL}: HTTP 404"
+    assert result.startswith(f"Error: Could not fetch {BOOKMARK_URL}: HTTP 404"), result
+    assert "browser tab:" in result, result
     assert "Source: failure for" in log, log
     return True
 
@@ -413,7 +559,7 @@ def test_doi_meta_ignored_when_url_has_no_doi():
     response = FakeResponse(text=html, url=url)
     with _fake_webloc(url), _fetch_returns(response), _crossref_raises():
         with _patched(web_source, "browser_tab_dom",
-                      lambda u: (_ for _ in ()).throw(
+                      lambda u, log=None: (_ for _ in ()).throw(
                           AssertionError("browser_tab_dom() should not have been called"))):
             result, log = _run(url=url)
     assert not isinstance(result, str), result
@@ -428,7 +574,7 @@ def test_ordinary_fetch_success_does_not_touch_fallbacks():
     response = FakeResponse(text=_article_html(), url=BOOKMARK_URL)
     with _fake_webloc(), _fetch_returns(response), _crossref_raises():
         with _patched(web_source, "browser_tab_dom",
-                      lambda url: (_ for _ in ()).throw(
+                      lambda url, log=None: (_ for _ in ()).throw(
                           AssertionError("browser_tab_dom() should not have been called"))):
             result, log = _run()
     assert not isinstance(result, str), result
@@ -439,6 +585,11 @@ def test_ordinary_fetch_success_does_not_touch_fallbacks():
 
 
 TESTS = [
+    test_browser_probe_reports_apple_events_refusal,
+    test_browser_probe_reports_not_running,
+    test_browser_probe_names_the_tabs_it_saw_on_no_match,
+    test_browser_probe_distinguishes_js_refusal_from_missing_tab,
+    test_browser_probe_captures_a_matching_tab,
     test_browser_challenge_markup_produces_amber_entry,
     test_browser_thin_dom_produces_amber_entry,
     test_browser_genuine_article_succeeds,
@@ -448,8 +599,9 @@ TESTS = [
     test_correspondence_mismatch_hard_fails_regardless_of_metadata_completeness,
     test_browser_wrong_doi_falls_through,
     test_no_tab_falls_back_to_crossref,
-    test_no_tab_no_doi_clean_failure_unchanged_text,
-    test_non_challenge_failure_skips_crossref_unchanged_text,
+    test_no_tab_no_doi_failure_names_the_browser_outcome,
+    test_failure_text_distinguishes_refusal_from_absent_tab,
+    test_non_challenge_failure_skips_crossref,
     test_browser_tried_on_non_challenge_status,
     test_fetch_canonical_matches_redirected_url_not_bookmark,
     test_doi_meta_ignored_when_url_has_no_doi,

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -190,6 +190,7 @@ def test_browser_thin_dom_falls_through():
          _browser_returns(_thin_html()), _no_crossref():
         result, log = _run()
     assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "browser tab" in log and "rejected" in log, log
     assert "words" in log, log
     return True
 
@@ -248,6 +249,7 @@ def test_no_tab_no_doi_clean_failure_unchanged_text():
         result, log = _run()
     assert result == (f"Error: {BOOKMARK_URL} is behind a bot challenge (HTTP 403) "
                        f"and its URL carries no DOI to fall back on")
+    assert "Source: failure for" in log, log
     return True
 
 
@@ -258,6 +260,7 @@ def test_non_challenge_failure_skips_crossref_unchanged_text():
          _no_browser_tab(), _crossref_raises():
         result, log = _run()
     assert result == f"Error: Could not fetch {BOOKMARK_URL}: HTTP 404"
+    assert "Source: failure for" in log, log
     return True
 
 
@@ -270,6 +273,7 @@ def test_browser_tried_on_non_challenge_status():
         result, log = _run()
     assert not isinstance(result, str), result
     assert "Chrome" in result.label
+    assert "Source: browser tab (Chrome) for" in log, log
     return True
 
 
@@ -284,6 +288,31 @@ def test_fetch_canonical_matches_redirected_url_not_bookmark():
         result, log = _run(url=doi_url)
     assert not isinstance(result, str), result
     assert "Source: fetch" in log, log
+    return True
+
+
+def test_doi_meta_ignored_when_url_has_no_doi():
+    # Most publisher URLs (Oxford Academic's own /article/80/1/1/1234567
+    # among them) carry no DOI in the path at all, even though the page's
+    # own citation_doi meta tag almost always exists. If that URL is the
+    # only candidate and the page has no canonical/og:url, the embedded DOI
+    # must not become the sole signal and reject an ordinary article for a
+    # "mismatch" that was never checkable in the first place.
+    url = "https://academic.oup.com/jaac/article/80/1/1/1234567"
+    html = (
+        "<title>A Study of Musical Form</title>"
+        '<meta name="citation_author" content="Doe, Jane">'
+        '<meta name="citation_doi" content="10.1093/jaac/kpag034">'
+    )
+    html = f"<html><head>{html}</head><body><p>{_words(150)}</p></body></html>"
+    response = FakeResponse(text=html, url=url)
+    with _fake_webloc(url), _fetch_returns(response), _crossref_raises():
+        with _patched(web_source, "browser_tab_dom",
+                      lambda u: (_ for _ in ()).throw(
+                          AssertionError("browser_tab_dom() should not have been called"))):
+            result, log = _run(url=url)
+    assert not isinstance(result, str), result
+    assert "Source: fetch for" in log, log
     return True
 
 
@@ -313,6 +342,7 @@ TESTS = [
     test_non_challenge_failure_skips_crossref_unchanged_text,
     test_browser_tried_on_non_challenge_status,
     test_fetch_canonical_matches_redirected_url_not_bookmark,
+    test_doi_meta_ignored_when_url_has_no_doi,
     test_ordinary_fetch_success_does_not_touch_fallbacks,
 ]
 

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -121,6 +121,33 @@ def _wrong_canonical_but_complete_html():
     )
 
 
+# The reported Silverchair case, recorded from the real failure: the
+# publisher serves the work at /article-abstract/ (what the bookmark holds,
+# with a ?redirectedFrom parameter) and declares /article/ as canonical.
+# Everything identifying is shared - host, journal, volume, issue, page,
+# article id 218886 and title slug; only the path *form* differs.
+UCPRESS_CANONICAL = ("https://online.ucpress.edu/ncm/article/50/1/54/218886/"
+                     "Fatigued-Voices-and-Vocal-Health-in-fine-secolo")
+# Same host and journal, different work: different article id AND slug.
+UCPRESS_OTHER_ARTICLE = ("https://online.ucpress.edu/ncm/article/50/1/70/218999/"
+                         "A-Completely-Different-Article-Title")
+
+
+def _ucpress_html(canonical):
+    """A real-shaped Silverchair article page, parameterised by the canonical
+    link so the same fixture serves the positive and negative cases."""
+    return (
+        "<html><head>"
+        "<title>Fatigued Voices and Vocal Health in fine secolo Italy</title>"
+        '<meta name="citation_title" content="Fatigued Voices and Vocal Health '
+        'in fine secolo Italy">'
+        '<meta name="citation_author" content="Rothstein, Edward">'
+        '<meta name="citation_publication_date" content="2026/07/01">'
+        f'<link rel="canonical" href="{canonical}">'
+        "</head><body><p>" + _words(200, prefix="prose") + "</p></body></html>"
+    )
+
+
 class FakeResponse:
     def __init__(self, status_code=200, text="", headers=None, url=None):
         self.status_code = status_code
@@ -532,6 +559,71 @@ def test_thin_body_at_fetch_produces_amber():
     return True
 
 
+def test_canonical_differing_only_in_path_form_is_accepted():
+    # The reported case. The publisher's canonical link is its own statement
+    # of where this work lives; treating /article/ vs /article-abstract/ as
+    # a different document rejected a correctly captured 114KB article page
+    # and would fire on every Silverchair platform.
+    with _fake_webloc(UCPRESS_URL), _fetch_returns(CLOUDFLARE_403()), \
+         _browser_returns(_ucpress_html(UCPRESS_CANONICAL)), _crossref_raises():
+        result, log = _run()
+    assert not isinstance(result, str), result
+    assert result.metadata.get("Title") == ("Fatigued Voices and Vocal Health "
+                                             "in fine secolo Italy")
+    assert "Source: browser tab (Safari)" in log, log
+    return True
+
+
+def test_same_host_different_article_id_is_still_rejected():
+    # The negative the loosening must not cost: a tab on the same host
+    # showing an unrelated article. Host agreement alone is not identity -
+    # a false match here files a confident wrong entry, which is worse than
+    # any failure.
+    with _fake_webloc(UCPRESS_URL), _fetch_returns(CLOUDFLARE_403()), \
+         _browser_returns(_ucpress_html(UCPRESS_OTHER_ARTICLE)), _no_crossref():
+        result, log = _run()
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "browser tab" in log and "rejected" in log, log
+    return True
+
+
+def test_url_identity_accepts_path_forms_and_refuses_other_works():
+    # _url_matches directly, over the shapes a publisher actually serves.
+    same = [
+        UCPRESS_CANONICAL,
+        "https://online.ucpress.edu/ncm/article-pdf/50/1/54/218886/"
+        "Fatigued-Voices-and-Vocal-Health-in-fine-secolo.pdf",
+        "https://online.ucpress.edu/ncm/advance-article-abstract/50/1/54/218886/"
+        "Fatigued-Voices-and-Vocal-Health-in-fine-secolo",
+    ]
+    for other in same:
+        assert web_source._url_matches(UCPRESS_URL, other), other
+
+    different = [
+        UCPRESS_OTHER_ARTICLE,                                  # another article
+        "https://online.ucpress.edu/ncm/issue/50/1",            # the issue, not the work
+        "https://online.ucpress.edu/login",                     # a login wall
+        # Same path entirely, different host - never the same work.
+        "https://academic.oup.com/ncm/article/50/1/54/218886/"
+        "Fatigued-Voices-and-Vocal-Health-in-fine-secolo",
+        # A shared four-digit year must not read as a shared article id,
+        # which is why the id pattern requires five digits.
+        "https://x.org/j/2020/article/A-Long-Enough-Slug-Two",
+    ]
+    for other in different:
+        assert not web_source._url_matches(UCPRESS_URL, other), other
+    assert not web_source._url_matches(
+        "https://x.org/j/2020/article/A-Long-Enough-Slug-One",
+        "https://x.org/j/2020/article/A-Long-Enough-Slug-Two")
+
+    # A segment built only of structural words identifies nothing, however
+    # long: two different works both carry `advance-article-abstract`.
+    assert not web_source._url_matches(
+        "https://x.org/j/advance-article-abstract/1/2",
+        "https://x.org/j/advance-article-abstract/9/9")
+    return True
+
+
 def test_browser_wrong_canonical_falls_through():
     # #11 item 4, case 5. Still a hard failure under the amber split: this
     # is the one condition that stays a failure regardless.
@@ -714,6 +806,9 @@ TESTS = [
     test_browser_genuine_article_succeeds,
     test_title_and_urldate_only_produces_amber,
     test_thin_body_at_fetch_produces_amber,
+    test_canonical_differing_only_in_path_form_is_accepted,
+    test_same_host_different_article_id_is_still_rejected,
+    test_url_identity_accepts_path_forms_and_refuses_other_works,
     test_browser_wrong_canonical_falls_through,
     test_correspondence_mismatch_hard_fails_regardless_of_metadata_completeness,
     test_browser_wrong_doi_falls_through,

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -23,6 +23,7 @@ import io
 import sys
 from contextlib import contextmanager, redirect_stderr
 from pathlib import Path
+from urllib.parse import urlsplit
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
@@ -795,6 +796,109 @@ def test_tab_selection_picks_the_wanted_article_from_among_its_siblings():
     return True
 
 
+# Platform shapes beyond Silverchair. PROVENANCE, because it differs from
+# SAME_ISSUE_ARTICLES above and the difference matters: those three are
+# recorded verbatim from the publisher. THESE ARE NOT RECORDINGS. They are
+# each platform's documented path grammar with the opaque identifiers filled
+# in by hand - no URL here was fetched, and no live request was made anywhere
+# in building this file. The grammar is what is under test (which segment
+# carries the work's identity, and which is a container shared by every work
+# on the platform), and that is stable; the digits are not evidence of
+# anything. Replace any of these with a real URL when one is to hand.
+#
+# Two of these caught real false matches that Silverchair-only fixtures could
+# never have surfaced:
+#
+#   Cambridge Core  /journals/<journal-slug>/article/abs/<title>/<hex id>
+#     the journal slug is shared by every article in the journal;
+#   Grove Music     /view/10.1093/gmo/<dictionary id>/<entry slug>
+#     the dictionary id is shared by every entry, AND the truncated DOI
+#     ladder shares the 10.1093/gmo stem.
+#
+# The rule assumed the long hyphenated segment was always a title. On
+# Silverchair it is (the journal is a short code, `ncm`); on Cambridge and
+# Grove it is the container. That is precisely the accent a single-publisher
+# fixture set builds in.
+
+_CAMBRIDGE = ("https://www.cambridge.org/core/journals/twentieth-century-music"
+              "/article/abs/sounding-the-archive/3C8B1F2A9D4E5061728394A5B6C7D8E9")
+_GROVE = ("https://www.oxfordmusiconline.com/grovemusic/view/10.1093/gmo/"
+          "9781561592630.001.0001/omo-9781561592630-e-0000040055")
+_TANDF = "https://www.tandfonline.com/doi/full/10.1080/07494467.2020.1717875"
+
+# (label, one, other) - different works that must never match.
+DIFFERENT_WORKS = (
+    ("Cambridge: two articles in one journal", _CAMBRIDGE,
+     _CAMBRIDGE.replace("sounding-the-archive/3C8B1F2A9D4E5061728394A5B6C7D8E9",
+                        "listening-otherwise/9F8E7D6C5B4A3021FEDCBA0987654321")),
+    ("Grove: two entries in one dictionary", _GROVE, _GROVE.replace("40055", "40056")),
+    ("SEP: two entries", "https://plato.stanford.edu/entries/qualia/",
+     "https://plato.stanford.edu/entries/emotion/"),
+    ("SEP: entry vs a dated archive of it", "https://plato.stanford.edu/entries/qualia/",
+     "https://plato.stanford.edu/archives/spr2021/entries/qualia/"),
+    ("Wikipedia: two articles", "https://en.wikipedia.org/wiki/Sonata_form",
+     "https://en.wikipedia.org/wiki/Rondo"),
+    ("manufacturer: two products",
+     "https://www.neumann.com/en-en/products/microphones/u-87-ai",
+     "https://www.neumann.com/en-en/products/microphones/tlm-103"),
+    ("JSTOR: two stable ids", "https://www.jstor.org/stable/40285017",
+     "https://www.jstor.org/stable/40285018"),
+    ("Project MUSE: two articles", "https://muse.jhu.edu/article/745211",
+     "https://muse.jhu.edu/article/745212"),
+    ("arXiv: two preprints", "https://arxiv.org/abs/2401.01234",
+     "https://arxiv.org/abs/2401.01235"),
+    ("repository handle: two items", "https://dspace.mit.edu/handle/1721.1/12345",
+     "https://dspace.mit.edu/handle/1721.1/12346"),
+    ("ScienceDirect: two PIIs",
+     "https://www.sciencedirect.com/science/article/pii/S0304422X20300310",
+     "https://www.sciencedirect.com/science/article/pii/S0304422X20300311"),
+    ("Taylor & Francis: two DOIs", _TANDF, _TANDF.replace("1717875", "1717876")),
+    ("Silverchair: two DOIs",
+     "https://academic.oup.com/jaac/doi/10.1093/jaac/kpag034/8725072",
+     "https://academic.oup.com/jaac/doi/10.1093/jaac/kpag099/8725099"),
+)
+
+# (label, one, other) - one work, served two ways; these must match.
+SAME_WORK_DIFFERENT_FORM = (
+    ("Cambridge: /article/abs/ vs /article/", _CAMBRIDGE,
+     _CAMBRIDGE.replace("/article/abs/", "/article/")),
+    ("Grove: /view/ vs /abstract/", _GROVE, _GROVE.replace("/view/", "/abstract/")),
+    ("Taylor & Francis: /full/ vs /abs/", _TANDF, _TANDF.replace("/full/", "/abs/")),
+    ("Silverchair: DOI with and without the trailing article id",
+     "https://academic.oup.com/jaac/doi/10.1093/jaac/kpag034/8725072",
+     "https://academic.oup.com/jaac/doi/10.1093/jaac/kpag034"),
+)
+
+
+def test_different_works_never_match_across_platforms():
+    for label, one, other in DIFFERENT_WORKS:
+        assert not web_source._url_matches(one, other), label
+        assert not web_source._url_matches(other, one), label + " (reversed)"
+    return True
+
+
+def test_one_work_served_two_ways_matches_across_platforms():
+    for label, one, other in SAME_WORK_DIFFERENT_FORM:
+        assert web_source._url_matches(one, other), label
+        assert web_source._url_matches(other, one), label + " (reversed)"
+    return True
+
+
+def test_shapes_without_an_identifier_fall_back_to_exact_matching():
+    # An acceptable outcome, and worth pinning: where a URL carries no
+    # identifying segment at all, only an exact match can succeed. Silently
+    # matching the wrong thing is the unacceptable outcome; declining to
+    # match a legitimate variant is not.
+    for url in ("https://plato.stanford.edu/entries/qualia/",
+                "https://en.wikipedia.org/wiki/Sonata_form",
+                "https://example.ac.uk/~smith/papers.html"):
+        ids, slugs = web_source._identifying_segments(urlsplit(url).path)
+        assert not ids and not slugs, (url, ids, slugs)
+        assert web_source._url_matches(url, url), url
+        assert web_source._url_matches(url, url.rstrip('/') + '/'), url
+    return True
+
+
 def test_browser_wrong_canonical_falls_through():
     # #11 item 4, case 5. Still a hard failure under the amber split: this
     # is the one condition that stays a failure regardless.
@@ -989,6 +1093,9 @@ TESTS = [
     test_each_same_issue_article_still_matches_its_own_canonical,
     test_tab_selection_ignores_sibling_articles_from_the_same_issue,
     test_tab_selection_picks_the_wanted_article_from_among_its_siblings,
+    test_different_works_never_match_across_platforms,
+    test_one_work_served_two_ways_matches_across_platforms,
+    test_shapes_without_an_identifier_fall_back_to_exact_matching,
     test_browser_wrong_canonical_falls_through,
     test_correspondence_mismatch_hard_fails_regardless_of_metadata_completeness,
     test_browser_wrong_doi_falls_through,

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -1,0 +1,339 @@
+#!/usr/bin/env python3
+"""
+Self-test for web_source.py's fallback/plausibility redesign (#11).
+
+No network, no browser, no API call: requests.get(), browser_tab_dom() and
+crossref_fallback() are all monkeypatched to canned values. The failure this
+exists to cover - a live Cloudflare challenge, or a half-loaded tab - can't
+be staged by hand (a logged-in browser passes every challenge; a private
+window doesn't reproduce a half-loaded DOM either), so this is the only place
+it's actually checked.
+
+    python3 dev/test_web_source.py
+"""
+
+from __future__ import annotations
+
+import io
+import sys
+from contextlib import contextmanager, redirect_stderr
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
+
+import web_source  # noqa: E402
+
+
+# ── fixtures ─────────────────────────────────────────────────────────────
+
+# Silverchair-shaped, with the DOI embedded in the path (see
+# doi_candidates()'s own docstring) - needed so a stubbed CrossRef record for
+# this DOI passes the URL-correspondence check the same way a real one would.
+BOOKMARK_URL = "https://academic.oup.com/jaac/doi/10.1093/jaac/kpag034/8725072"
+
+
+def _words(n, prefix="word"):
+    return " ".join(f"{prefix}{i}" for i in range(n))
+
+
+def _article_html(canonical=BOOKMARK_URL, doi="10.1093/jaac/kpag034"):
+    """A genuine article page: Title, Author, a matching canonical link, and
+    well over MIN_BODY_WORDS of body text."""
+    return (
+        "<html><head>"
+        "<title>A Study of Musical Form</title>"
+        '<meta name="citation_title" content="A Study of Musical Form">'
+        '<meta name="citation_author" content="Doe, Jane">'
+        f'<meta name="citation_doi" content="{doi}">'
+        f'<link rel="canonical" href="{canonical}">'
+        "</head><body><p>" + _words(150) + "</p></body></html>"
+    )
+
+
+def _challenge_html():
+    """Built from the same markers is_bot_challenge() itself looks for, so
+    this fixture can't drift out of step with the detector it stands in for."""
+    marker = web_source._CHALLENGE_BODY_MARKERS[0]
+    return f"<html><head><title>{marker}</title></head><body>{marker}</body></html>"
+
+
+def _thin_html():
+    """Identifying metadata is present (Title, Author) but the body is a
+    handful of words - a tab still loading, not an interstitial."""
+    return (
+        "<html><head><title>A Study of Musical Form</title>"
+        '<meta name="citation_author" content="Doe, Jane"></head>'
+        "<body><p>Loading…</p></body></html>"
+    )
+
+
+def _consent_wall_html():
+    """Title only, nothing identifying a work - what a login/consent wall
+    typically carries, and what a plain 200 response gives no other way to
+    catch."""
+    return (
+        "<html><head><title>Please accept cookies to continue</title></head>"
+        "<body><p>" + _words(150, prefix="cookie") + "</p></body></html>"
+    )
+
+
+def _wrong_canonical_html():
+    """Otherwise-plausible content whose canonical link names a different
+    page entirely - no og:url or Doi present to rescue it."""
+    return (
+        "<html><head><title>A Study of Musical Form</title>"
+        '<meta name="citation_author" content="Doe, Jane">'
+        '<link rel="canonical" href="https://academic.oup.com/login"></head>'
+        "<body><p>" + _words(150) + "</p></body></html>"
+    )
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, text="", headers=None, url=None):
+        self.status_code = status_code
+        self.text = text
+        self.content = text.encode("utf-8")
+        self.headers = headers or {}
+        self.url = url if url is not None else BOOKMARK_URL
+
+    @property
+    def ok(self):
+        return self.status_code < 400
+
+
+CLOUDFLARE_403 = lambda: FakeResponse(  # noqa: E731
+    status_code=403, headers={"cf-mitigated": "challenge"}, text="cf challenge body"
+)
+PLAIN_404 = lambda: FakeResponse(status_code=404, text="not found")  # noqa: E731
+
+
+@contextmanager
+def _patched(obj, name, value):
+    original = getattr(obj, name)
+    setattr(obj, name, value)
+    try:
+        yield
+    finally:
+        setattr(obj, name, original)
+
+
+def _fake_webloc(tmp_path_url=BOOKMARK_URL):
+    """resolve_webloc() is not under test here - patched to hand back a URL
+    directly so no actual .webloc file has to exist on disk."""
+    return _patched(web_source, "resolve_webloc", lambda path: tmp_path_url)
+
+
+def _no_browser_tab():
+    return _patched(web_source, "browser_tab_dom", lambda url: (None, None))
+
+
+def _browser_returns(html, app="Safari"):
+    return _patched(web_source, "browser_tab_dom", lambda url: (html, app))
+
+
+def _no_crossref():
+    return _patched(web_source, "crossref_fallback", lambda url, crossref_email=None: None)
+
+
+def _crossref_raises():
+    def _boom(url, crossref_email=None):
+        raise AssertionError("crossref_fallback() should not have been called")
+    return _patched(web_source, "crossref_fallback", _boom)
+
+
+def _crossref_returns_article():
+    message = {
+        "title": ["A Study of Musical Form"],
+        "author": [{"family": "Doe", "given": "Jane"}],
+        "DOI": "10.1093/jaac/kpag034",
+        "published-print": {"date-parts": [[2020, 1]]},
+    }
+    content = web_source._crossref_content(message, BOOKMARK_URL)
+    return _patched(web_source, "crossref_fallback", lambda url, crossref_email=None: content)
+
+
+def _fetch_returns(response):
+    return _patched(web_source.requests, "get",
+                     lambda url, headers=None, timeout=None: response)
+
+
+def _run(url=BOOKMARK_URL):
+    """extract_webloc() with a dummy path - resolve_webloc() is patched by
+    every test via _fake_webloc(), so the path itself is never opened, only
+    checked for existence."""
+    with _patched(Path, "exists", lambda self: True):
+        err = io.StringIO()
+        with redirect_stderr(err):
+            result = web_source.extract_webloc("dummy.webloc")
+        return result, err.getvalue()
+
+
+# ── tests ────────────────────────────────────────────────────────────────
+
+def test_browser_challenge_markup_falls_through():
+    # #11 item 4, case 1: browser_tab_dom() hands back an actual Cloudflare
+    # interstitial - no entry, and the rejection is logged against the
+    # browser path.
+    with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+         _browser_returns(_challenge_html()), _no_crossref():
+        result, log = _run()
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "browser tab" in log and "rejected" in log, log
+    return True
+
+
+def test_browser_thin_dom_falls_through():
+    # #11 item 4, case 2: identifying metadata is present, but the body is
+    # a handful of words - a tab still loading, not an interstitial. Length
+    # guard fires specifically (metadata check alone would pass this one).
+    with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+         _browser_returns(_thin_html()), _no_crossref():
+        result, log = _run()
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "words" in log, log
+    return True
+
+
+def test_browser_genuine_article_succeeds():
+    # #11 item 4, case 3: without this one, the first two pass trivially
+    # even if the capture path is broken outright.
+    with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+         _browser_returns(_article_html(), app="Safari"):
+        result, log = _run()
+    assert not isinstance(result, str), result
+    assert result.metadata.get("Title") == "A Study of Musical Form"
+    assert result.metadata.get("Author") == "Doe, Jane"
+    assert "Safari" in result.label
+    assert "Source: browser tab (Safari)" in log, log
+    return True
+
+
+def test_200_interstitial_rejected():
+    # #11 item 4, case 4: the hole the whole redesign is for - a 200
+    # response is never routed through is_bot_challenge at all.
+    with _fake_webloc(), _fetch_returns(FakeResponse(text=_consent_wall_html())), \
+         _no_browser_tab():
+        result, log = _run()
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "fetch" in log and "rejected" in log, log
+    return True
+
+
+def test_browser_wrong_canonical_falls_through():
+    # #11 item 4, case 5.
+    with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+         _browser_returns(_wrong_canonical_html()), _no_crossref():
+        result, log = _run()
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "browser tab" in log and "rejected" in log, log
+    return True
+
+
+def test_no_tab_falls_back_to_crossref():
+    # #11 item 4, case 6 (the DOI-fallback branch): unchanged from #8/#10.
+    with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+         _no_browser_tab(), _crossref_returns_article():
+        result, log = _run()
+    assert not isinstance(result, str), result
+    assert result.label == "CrossRef record"
+    assert "Source: CrossRef for" in log, log
+    return True
+
+
+def test_no_tab_no_doi_clean_failure_unchanged_text():
+    # #11 item 4, case 6 (the plain-failure branch), challenge classified:
+    # no tab, no CrossRef hit - the pre-#11 error text, unchanged.
+    with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+         _no_browser_tab(), _no_crossref():
+        result, log = _run()
+    assert result == (f"Error: {BOOKMARK_URL} is behind a bot challenge (HTTP 403) "
+                       f"and its URL carries no DOI to fall back on")
+    return True
+
+
+def test_non_challenge_failure_skips_crossref_unchanged_text():
+    # A plain 404 never satisfies is_bot_challenge, so crossref_fallback()
+    # must never even be called for it - the original gate, preserved.
+    with _fake_webloc(), _fetch_returns(PLAIN_404()), \
+         _no_browser_tab(), _crossref_raises():
+        result, log = _run()
+    assert result == f"Error: Could not fetch {BOOKMARK_URL}: HTTP 404"
+    return True
+
+
+def test_browser_tried_on_non_challenge_status():
+    # #11 item 1: browser_tab_dom() must be tried on ANY non-2xx, not only
+    # a classified challenge - a plain 404 with a matching tab open still
+    # succeeds via the browser, which the pre-#11 gate would never reach.
+    with _fake_webloc(), _fetch_returns(PLAIN_404()), \
+         _browser_returns(_article_html(), app="Chrome"), _crossref_raises():
+        result, log = _run()
+    assert not isinstance(result, str), result
+    assert "Chrome" in result.label
+    return True
+
+
+def test_fetch_canonical_matches_redirected_url_not_bookmark():
+    # A doi.org bookmark resolves to the publisher's own URL; the page's
+    # canonical link then names that resolved URL, not the redirector. The
+    # correspondence check must accept a signal matching EITHER candidate.
+    doi_url = "https://doi.org/10.1093/jaac/kpag034"
+    resolved_url = BOOKMARK_URL
+    response = FakeResponse(text=_article_html(canonical=resolved_url), url=resolved_url)
+    with _fake_webloc(doi_url), _fetch_returns(response):
+        result, log = _run(url=doi_url)
+    assert not isinstance(result, str), result
+    assert "Source: fetch" in log, log
+    return True
+
+
+def test_ordinary_fetch_success_does_not_touch_fallbacks():
+    # Sanity/regression: the common case still returns straight from the
+    # fetch, without ever invoking either fallback.
+    response = FakeResponse(text=_article_html(), url=BOOKMARK_URL)
+    with _fake_webloc(), _fetch_returns(response), _crossref_raises():
+        with _patched(web_source, "browser_tab_dom",
+                      lambda url: (_ for _ in ()).throw(
+                          AssertionError("browser_tab_dom() should not have been called"))):
+            result, log = _run()
+    assert not isinstance(result, str), result
+    assert result.label == "webpage"
+    assert "Source: fetch for" in log, log
+    return True
+
+
+TESTS = [
+    test_browser_challenge_markup_falls_through,
+    test_browser_thin_dom_falls_through,
+    test_browser_genuine_article_succeeds,
+    test_200_interstitial_rejected,
+    test_browser_wrong_canonical_falls_through,
+    test_no_tab_falls_back_to_crossref,
+    test_no_tab_no_doi_clean_failure_unchanged_text,
+    test_non_challenge_failure_skips_crossref_unchanged_text,
+    test_browser_tried_on_non_challenge_status,
+    test_fetch_canonical_matches_redirected_url_not_bookmark,
+    test_ordinary_fetch_success_does_not_touch_fallbacks,
+]
+
+
+def main():
+    failures = []
+    for test in TESTS:
+        try:
+            assert test() is True
+            print(f"  ✓ {test.__name__}")
+        except Exception as e:
+            failures.append((test.__name__, e))
+            print(f"  ✗ {test.__name__}: {e}")
+
+    print()
+    if failures:
+        print(f"{len(failures)}/{len(TESTS)} test(s) failed.")
+        return 1
+    print(f"All {len(TESTS)} web_source self-tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -413,6 +413,87 @@ def test_duplicate_windows_do_not_confuse_the_index():
     return True
 
 
+def _listing(*rows):
+    """A tab listing in Safari's real format from (window, tab, url) rows."""
+    return "".join(f"{w}\t{t}\t{u}\n" for w, t, u in rows)
+
+
+def test_tab_selection_falls_back_to_identity_when_no_tab_matches_exactly():
+    # The path-form mismatch that no query-parameter rule reaches: the
+    # bookmark holds /article-abstract/, the open tab holds /article/.
+    listing = _listing(
+        (1, 1, "https://example1.invalid/page1"),
+        (1, 2, UCPRESS_CANONICAL),
+    )
+    with _osa(listing=listing, capture="<html>ok</html>"):
+        html, app, summary, log = _probe(UCPRESS_URL)
+    assert html == "<html>ok</html>", html
+    assert "identity" in summary, summary
+    assert "matched window 1 tab 2 (identity match:" in log, log
+    # The tab's own URL is named, since it is not the address asked for.
+    assert UCPRESS_CANONICAL in log, log
+    return True
+
+
+def test_tab_selection_prefers_an_exact_match_over_an_identity_match():
+    # Same article open in two forms. The one actually asked for wins, even
+    # though the identity match comes first in enumeration order.
+    listing = _listing(
+        (1, 1, UCPRESS_CANONICAL),   # identity match, earlier
+        (1, 2, UCPRESS_URL),         # exact match, later
+    )
+    with _osa(listing=listing, capture="<html>ok</html>"):
+        html, app, summary, log = _probe(UCPRESS_URL)
+    assert html == "<html>ok</html>"
+    assert "exact" in summary, summary
+    assert "matched window 1 tab 2 (exact match)" in log, log
+    return True
+
+
+def test_exact_match_wins_across_windows_not_just_within_one():
+    # The exact match sits in the SECOND window, behind an identity match in
+    # the first - preference must not degrade into "earliest tab wins".
+    listing = _listing(
+        (1, 1, UCPRESS_CANONICAL),
+        (2, 1, UCPRESS_URL),
+    )
+    with _osa(listing=listing, capture="<html>ok</html>"):
+        html, app, summary, log = _probe(UCPRESS_URL)
+    assert "matched window 2 tab 1 (exact match)" in log, log
+    return True
+
+
+def test_identity_fallback_takes_the_earliest_window_and_tab():
+    # Three identity matches, none exact. Selection must be deterministic and
+    # take the first in window-then-tab order.
+    listing = _listing(
+        (1, 1, "https://example1.invalid/page1"),
+        (1, 3, "https://online.ucpress.edu/ncm/article-pdf/50/1/54/218886/"
+               "Fatigued-Voices-and-Vocal-Health-in-fine-secolo.pdf"),
+        (2, 1, UCPRESS_CANONICAL),
+        (2, 2, "https://online.ucpress.edu/ncm/advance-article-abstract/50/1/54/"
+               "218886/Fatigued-Voices-and-Vocal-Health-in-fine-secolo"),
+    )
+    with _osa(listing=listing, capture="<html>ok</html>"):
+        html, app, summary, log = _probe(UCPRESS_URL)
+    assert "matched window 1 tab 3 (identity match:" in log, log
+    return True
+
+
+def test_tab_selection_refuses_a_different_article_on_the_same_host():
+    # Tab selection has no backstop - a wrong tab means the wrong document is
+    # captured outright - so the negative matters more here than anywhere.
+    listing = _listing(
+        (1, 1, UCPRESS_OTHER_ARTICLE),
+        (1, 2, "https://online.ucpress.edu/ncm/issue/50/1"),
+    )
+    with _osa(listing=listing, capture="<html>should never be captured</html>"):
+        html, app, summary, log = _probe(UCPRESS_URL)
+    assert html is None, html
+    assert "no matching tab" in summary, summary
+    return True
+
+
 def test_browser_probe_reports_apple_events_refusal():
     # State 1. Previously indistinguishable from "no tab" - the conflation
     # that made a single failure take three rounds to diagnose.
@@ -797,6 +878,11 @@ TESTS = [
     test_broken_listing_is_reported_as_a_parse_error_not_as_no_tabs,
     test_non_http_scheme_does_not_break_the_listing,
     test_duplicate_windows_do_not_confuse_the_index,
+    test_tab_selection_falls_back_to_identity_when_no_tab_matches_exactly,
+    test_tab_selection_prefers_an_exact_match_over_an_identity_match,
+    test_exact_match_wins_across_windows_not_just_within_one,
+    test_identity_fallback_takes_the_earliest_window_and_tab,
+    test_tab_selection_refuses_a_different_article_on_the_same_host,
     test_browser_probe_reports_apple_events_refusal,
     test_browser_probe_reports_not_running,
     test_browser_probe_names_the_tabs_it_saw_on_no_match,

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -133,6 +133,39 @@ UCPRESS_OTHER_ARTICLE = ("https://online.ucpress.edu/ncm/article/50/1/70/218999/
                          "A-Completely-Different-Article-Title")
 
 
+# Three real articles from ONE issue of ONE journal - 19th-Century Music
+# 50/1 - recorded verbatim from the publisher. The adversarial set: nothing
+# discriminates them except the article id and the title slug.
+#
+#   - the ids are CONSECUTIVE and six digits (218886/218887/218888), so they
+#     differ by a single character - the sharpest available test of the id
+#     rule, and the case a substring or prefix comparison would fail;
+#   - volume, issue and page (/50/1/54/, /50/1/4/, /50/1/24/) are shared or
+#     near-shared and all fall below the five-digit floor, which is exactly
+#     what stops them counting as identifiers;
+#   - two of the three slugs both contain `Chopin-s`, so a matcher comparing
+#     substrings rather than whole segments would marry them.
+#
+# All three carry the same ?redirectedFrom=fulltext and the same
+# /article-abstract/ path form, so the query string and the path form are
+# constant across the set and cannot be doing any of the discriminating.
+SAME_ISSUE_ARTICLES = (
+    "https://online.ucpress.edu/ncm/article-abstract/50/1/54/218886/"
+    "Fatigued-Voices-and-Vocal-Health-in-fine-secolo?redirectedFrom=fulltext",
+    "https://online.ucpress.edu/ncm/article-abstract/50/1/4/218887/"
+    "Rehearing-Recursive-Cycles-in-Chopin-s-Preludes?redirectedFrom=fulltext",
+    "https://online.ucpress.edu/ncm/article-abstract/50/1/24/218888/"
+    "Object-Lesson-The-Personified-Voice-of-Chopin-s?redirectedFrom=fulltext",
+)
+
+
+def _canonical_form(url):
+    """The /article/ address the publisher declares canonical for a
+    /article-abstract/ one - the transformation this whole loosening exists
+    to tolerate."""
+    return url.replace("/article-abstract/", "/article/").split("?")[0]
+
+
 def _ucpress_html(canonical):
     """A real-shaped Silverchair article page, parameterised by the canonical
     link so the same fixture serves the positive and negative cases."""
@@ -705,6 +738,63 @@ def test_url_identity_accepts_path_forms_and_refuses_other_works():
     return True
 
 
+def test_same_issue_articles_never_match_one_another():
+    # Every ordered pair, both directions, at the correspondence site.
+    # Consecutive six-digit ids and two slugs sharing `Chopin-s` - if the id
+    # rule ever softens to a prefix, or slug comparison to a substring, this
+    # is what catches it.
+    for i, one in enumerate(SAME_ISSUE_ARTICLES):
+        for j, other in enumerate(SAME_ISSUE_ARTICLES):
+            if i == j:
+                continue
+            assert not web_source._url_matches(one, other), (one, other)
+            # Nor against a sibling's canonical form: the path-form
+            # loosening must not become a way in.
+            assert not web_source._url_matches(one, _canonical_form(other)), (one, other)
+    return True
+
+
+def test_each_same_issue_article_still_matches_its_own_canonical():
+    # The positive half, so the test above cannot pass by a matcher that
+    # simply refuses everything.
+    for url in SAME_ISSUE_ARTICLES:
+        assert web_source._url_matches(url, _canonical_form(url)), url
+    return True
+
+
+def test_tab_selection_ignores_sibling_articles_from_the_same_issue():
+    # The stricter site, with the same adversarial set. Two siblings open,
+    # the wanted article not open at all: nothing may be captured, because
+    # here a wrong tab means the wrong document is read outright.
+    wanted, sibling_a, sibling_b = SAME_ISSUE_ARTICLES
+    listing = _listing(
+        (1, 1, _canonical_form(sibling_a)),
+        (1, 2, _canonical_form(sibling_b)),
+    )
+    with _osa(listing=listing, capture="<html>should never be captured</html>"):
+        html, app, summary, log = _probe(wanted)
+    assert html is None, html
+    assert "no matching tab" in summary, summary
+    return True
+
+
+def test_tab_selection_picks_the_wanted_article_from_among_its_siblings():
+    # Same three tabs, the wanted article now open in its canonical form.
+    # It must be the one taken - not the first sibling encountered.
+    wanted, sibling_a, sibling_b = SAME_ISSUE_ARTICLES
+    listing = _listing(
+        (1, 1, _canonical_form(sibling_a)),
+        (1, 2, _canonical_form(sibling_b)),
+        (1, 3, _canonical_form(wanted)),
+    )
+    with _osa(listing=listing, capture="<html>ok</html>"):
+        html, app, summary, log = _probe(wanted)
+    assert html == "<html>ok</html>", html
+    assert "matched window 1 tab 3 (identity match:" in log, log
+    assert "218886" in log, log
+    return True
+
+
 def test_browser_wrong_canonical_falls_through():
     # #11 item 4, case 5. Still a hard failure under the amber split: this
     # is the one condition that stays a failure regardless.
@@ -895,6 +985,10 @@ TESTS = [
     test_canonical_differing_only_in_path_form_is_accepted,
     test_same_host_different_article_id_is_still_rejected,
     test_url_identity_accepts_path_forms_and_refuses_other_works,
+    test_same_issue_articles_never_match_one_another,
+    test_each_same_issue_article_still_matches_its_own_canonical,
+    test_tab_selection_ignores_sibling_articles_from_the_same_issue,
+    test_tab_selection_picks_the_wanted_article_from_among_its_siblings,
     test_browser_wrong_canonical_falls_through,
     test_correspondence_mismatch_hard_fails_regardless_of_metadata_completeness,
     test_browser_wrong_doi_falls_through,

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python3
 """
-Self-test for web_source.py's fallback/plausibility redesign (#11).
+Self-test for web_source.py's fallback/plausibility redesign (#11), and its
+amber-vs-fail follow-up: only a URL-correspondence mismatch (the wrong
+document) is a hard failure; a genuine source that's merely thin or sparse
+(no Author/Doi/PublicationDate beyond Urldate, or a short body) still
+produces a SourceContent, marked amber for a human glance rather than
+trusted blind or discarded.
 
 No network, no browser, no API call: requests.get(), browser_tab_dom() and
 crossref_fallback() are all monkeypatched to canned values. The failure this
@@ -100,6 +105,22 @@ def _wrong_canonical_html():
     )
 
 
+def _wrong_canonical_but_complete_html():
+    """Complete identifying metadata (Author, PublicationDate) and a long
+    body - deliberately no Doi, since a Doi embedded in BOOKMARK_URL's own
+    path would itself be a correspondence signal and could rescue a wrong
+    canonical, defeating the point. Complete by every OTHER measure except
+    the one that matters: its canonical link names a different page. The
+    hard-failure case must fire regardless of how complete the rest looks."""
+    return (
+        "<html><head><title>A Study of Musical Form</title>"
+        '<meta name="citation_author" content="Doe, Jane">'
+        '<meta name="citation_publication_date" content="2020/01/01">'
+        '<link rel="canonical" href="https://academic.oup.com/login"></head>'
+        "<body><p>" + _words(150) + "</p></body></html>"
+    )
+
+
 class FakeResponse:
     def __init__(self, status_code=200, text="", headers=None, url=None):
         self.status_code = status_code
@@ -182,28 +203,35 @@ def _run(url=BOOKMARK_URL):
 
 # ── tests ────────────────────────────────────────────────────────────────
 
-def test_browser_challenge_markup_falls_through():
-    # #11 item 4, case 1: browser_tab_dom() hands back an actual Cloudflare
-    # interstitial - no entry, and the rejection is logged against the
-    # browser path.
+def test_browser_challenge_markup_produces_amber_entry():
+    # #11 item 4, case 1, updated for the amber follow-up: a Cloudflare
+    # interstitial has no correspondence-contradicting signal of its own
+    # (no canonical/og:url/Doi), so it's no longer a hard failure - it's the
+    # sparsest possible source (no identifying field, a two-word body), and
+    # comes back amber on both counts rather than discarded.
     with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
-         _browser_returns(_challenge_html()), _no_crossref():
+         _browser_returns(_challenge_html()), _crossref_raises():
         result, log = _run()
-    assert isinstance(result, str) and result.startswith("Error:"), result
-    assert "browser tab" in log and "rejected" in log, log
+    assert not isinstance(result, str), result
+    assert result.amber is True
+    assert "Author/Doi/PublicationDate" in result.amber_reason, result.amber_reason
+    assert "words" in result.amber_reason, result.amber_reason
+    assert "Source: browser tab (Safari)" in log and "[amber:" in log, log
     return True
 
 
-def test_browser_thin_dom_falls_through():
-    # #11 item 4, case 2: identifying metadata is present, but the body is
-    # a handful of words - a tab still loading, not an interstitial. Length
-    # guard fires specifically (metadata check alone would pass this one).
+def test_browser_thin_dom_produces_amber_entry():
+    # #11 item 4, case 2, updated: identifying metadata is present (Title,
+    # Author), so only the length guard fires - a tab still loading, not an
+    # interstitial. Required new case: "Body under MIN_BODY_WORDS, content
+    # corresponding -> amber, not failure."
     with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
-         _browser_returns(_thin_html()), _no_crossref():
+         _browser_returns(_thin_html()), _crossref_raises():
         result, log = _run()
-    assert isinstance(result, str) and result.startswith("Error:"), result
-    assert "browser tab" in log and "rejected" in log, log
-    assert "words" in log, log
+    assert not isinstance(result, str), result
+    assert result.amber is True
+    assert result.amber_reason == f"body text under {web_source.MIN_BODY_WORDS} words"
+    assert "[amber:" in log, log
     return True
 
 
@@ -217,25 +245,72 @@ def test_browser_genuine_article_succeeds():
     assert result.metadata.get("Title") == "A Study of Musical Form"
     assert result.metadata.get("Author") == "Doe, Jane"
     assert "Safari" in result.label
-    assert "Source: browser tab (Safari)" in log, log
+    assert result.amber is False and result.amber_reason is None
+    assert "Source: browser tab (Safari)" in log and "[amber:" not in log, log
     return True
 
 
-def test_200_interstitial_rejected():
-    # #11 item 4, case 4: the hole the whole redesign is for - a 200
-    # response is never routed through is_bot_challenge at all.
+def test_title_and_urldate_only_produces_amber():
+    # #11 item 4, case 4 (the hole the original redesign was for), now
+    # folded into the amber split, and the first of the follow-up's three
+    # required new cases verbatim: "Title + Urldate only, content
+    # corresponding -> amber entry produced, not a failure." A 200 consent
+    # wall with a substantial body and no correspondence-contradicting
+    # signal is exactly this shape - no Author/Doi/PublicationDate, only
+    # Urldate (implied by having a URL at all) left to date it by. Resolved
+    # straight from the fetch: the browser path is never even tried.
     with _fake_webloc(), _fetch_returns(FakeResponse(text=_consent_wall_html())), \
-         _no_browser_tab():
-        result, log = _run()
-    assert isinstance(result, str) and result.startswith("Error:"), result
-    assert "fetch" in log and "rejected" in log, log
+         _crossref_raises():
+        with _patched(web_source, "browser_tab_dom",
+                      lambda url: (_ for _ in ()).throw(
+                          AssertionError("browser_tab_dom() should not have been called"))):
+            result, log = _run()
+    assert not isinstance(result, str), result
+    assert result.amber is True
+    assert result.amber_reason == "no Author/Doi/PublicationDate - only Urldate available to date it"
+    assert "Source: fetch for" in log and "[amber:" in log, log
+    return True
+
+
+def test_thin_body_at_fetch_produces_amber():
+    # Required new case, at the plain-fetch level rather than via a browser
+    # tab: full identifying metadata (Title, Author), but a body under
+    # MIN_BODY_WORDS - amber for length alone, nothing else.
+    html = (
+        "<html><head><title>A Study of Musical Form</title>"
+        '<meta name="citation_author" content="Doe, Jane"></head>'
+        "<body><p>Loading…</p></body></html>"
+    )
+    with _fake_webloc(), _fetch_returns(FakeResponse(text=html)), _crossref_raises():
+        with _patched(web_source, "browser_tab_dom",
+                      lambda url: (_ for _ in ()).throw(
+                          AssertionError("browser_tab_dom() should not have been called"))):
+            result, log = _run()
+    assert not isinstance(result, str), result
+    assert result.amber is True
+    assert result.amber_reason == f"body text under {web_source.MIN_BODY_WORDS} words"
     return True
 
 
 def test_browser_wrong_canonical_falls_through():
-    # #11 item 4, case 5.
+    # #11 item 4, case 5. Still a hard failure under the amber split: this
+    # is the one condition that stays a failure regardless.
     with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
          _browser_returns(_wrong_canonical_html()), _no_crossref():
+        result, log = _run()
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    assert "browser tab" in log and "rejected" in log, log
+    return True
+
+
+def test_correspondence_mismatch_hard_fails_regardless_of_metadata_completeness():
+    # Required new case, verbatim: "Content not corresponding to the
+    # requested URL -> hard failure, no entry, regardless of how complete
+    # its metadata looks." Every identifying field present (Author, Doi,
+    # PublicationDate) and a long body - only the canonical link is wrong,
+    # and that alone must still fail it.
+    with _fake_webloc(), _fetch_returns(CLOUDFLARE_403()), \
+         _browser_returns(_wrong_canonical_but_complete_html()), _no_crossref():
         result, log = _run()
     assert isinstance(result, str) and result.startswith("Error:"), result
     assert "browser tab" in log and "rejected" in log, log
@@ -264,7 +339,8 @@ def test_no_tab_falls_back_to_crossref():
         result, log = _run()
     assert not isinstance(result, str), result
     assert result.label == "CrossRef record"
-    assert "Source: CrossRef for" in log, log
+    assert result.amber is False and result.amber_reason is None
+    assert "Source: CrossRef for" in log and "[amber:" not in log, log
     return True
 
 
@@ -300,7 +376,8 @@ def test_browser_tried_on_non_challenge_status():
         result, log = _run()
     assert not isinstance(result, str), result
     assert "Chrome" in result.label
-    assert "Source: browser tab (Chrome) for" in log, log
+    assert result.amber is False
+    assert "Source: browser tab (Chrome) for" in log and "[amber:" not in log, log
     return True
 
 
@@ -314,7 +391,8 @@ def test_fetch_canonical_matches_redirected_url_not_bookmark():
     with _fake_webloc(doi_url), _fetch_returns(response):
         result, log = _run(url=doi_url)
     assert not isinstance(result, str), result
-    assert "Source: fetch" in log, log
+    assert result.amber is False
+    assert "Source: fetch" in log and "[amber:" not in log, log
     return True
 
 
@@ -339,7 +417,8 @@ def test_doi_meta_ignored_when_url_has_no_doi():
                           AssertionError("browser_tab_dom() should not have been called"))):
             result, log = _run(url=url)
     assert not isinstance(result, str), result
-    assert "Source: fetch for" in log, log
+    assert result.amber is False
+    assert "Source: fetch for" in log and "[amber:" not in log, log
     return True
 
 
@@ -354,16 +433,19 @@ def test_ordinary_fetch_success_does_not_touch_fallbacks():
             result, log = _run()
     assert not isinstance(result, str), result
     assert result.label == "webpage"
-    assert "Source: fetch for" in log, log
+    assert result.amber is False
+    assert "Source: fetch for" in log and "[amber:" not in log, log
     return True
 
 
 TESTS = [
-    test_browser_challenge_markup_falls_through,
-    test_browser_thin_dom_falls_through,
+    test_browser_challenge_markup_produces_amber_entry,
+    test_browser_thin_dom_produces_amber_entry,
     test_browser_genuine_article_succeeds,
-    test_200_interstitial_rejected,
+    test_title_and_urldate_only_produces_amber,
+    test_thin_body_at_fetch_produces_amber,
     test_browser_wrong_canonical_falls_through,
+    test_correspondence_mismatch_hard_fails_regardless_of_metadata_completeness,
     test_browser_wrong_doi_falls_through,
     test_no_tab_falls_back_to_crossref,
     test_no_tab_no_doi_clean_failure_unchanged_text,

--- a/dev/test_web_source.py
+++ b/dev/test_web_source.py
@@ -203,23 +203,79 @@ def _run(url=BOOKMARK_URL):
         return result, err.getvalue()
 
 
-# ── browser_tab_dom: the three states, via a stubbed subprocess.run ──────
+# ── browser_tab_dom, against Safari's REAL tab listing ───────────────────
 #
 # These are the only tests that exercise browser_tab_dom itself rather than
 # stubbing it. osascript is never invoked and no browser is touched: a fake
-# subprocess.run answers each AppleScript by what it asks for.
+# subprocess.run answers each AppleScript with recorded output.
+#
+# SAFARI_TAB_LISTING is a verbatim capture from a running Safari (26 tabs
+# across 2 windows), with unrelated URLs replaced by stand-ins through a
+# stable mapping, so everything structural survives:
+#
+#   - TWO windows, 14 tabs and 12 tabs, indices restarting per window;
+#   - 11 URLs open in BOTH windows, so a matcher that assumed tab URLs are
+#     unique, or that only window 1 exists, is caught;
+#   - the target at window 1, tab 12 - NOT tab 1, and not in the last window;
+#   - a non-http `favorites://` entry (Safari's Start Page) as the final tab.
+#
+# The previous version of these tests invented the listing format from the
+# AppleScript's apparent intent rather than recording what it actually
+# emits. It therefore encoded tab-separated fields that the real script
+# never produced, and passed while the enumeration was completely broken -
+# `tab` inside a `tell application "Safari"` block binds to Safari's `tab`
+# class, not the tab character, so every line came out as
+# "1tab1tabhttps://..." and every one was silently discarded. Recording the
+# real output is the whole point; do not hand-write this fixture.
+
+SAFARI_TAB_LISTING = (
+    "1\t1\thttps://example1.invalid/page1\n"
+    "1\t2\thttps://example2.invalid/page2\n"
+    "1\t3\thttps://example3.invalid/page3\n"
+    "1\t4\thttps://example4.invalid/page4\n"
+    "1\t5\thttps://example5.invalid/page5\n"
+    "1\t6\thttps://example6.invalid/page6\n"
+    "1\t7\thttps://example7.invalid/page7\n"
+    "1\t8\thttps://example8.invalid/page8\n"
+    "1\t9\thttps://example9.invalid/page9\n"
+    "1\t10\thttps://example10.invalid/page10\n"
+    "1\t11\thttps://example11.invalid/page11\n"
+    "1\t12\thttps://online.ucpress.edu/ncm/article-abstract/50/1/54/218886/"
+    "Fatigued-Voices-and-Vocal-Health-in-fine-secolo?redirectedFrom=fulltext\n"
+    "1\t13\thttps://example12.invalid/page12\n"
+    "1\t14\thttps://example13.invalid/page13\n"
+    "2\t1\thttps://example1.invalid/page1\n"
+    "2\t2\thttps://example2.invalid/page2\n"
+    "2\t3\thttps://example3.invalid/page3\n"
+    "2\t4\thttps://example4.invalid/page4\n"
+    "2\t5\thttps://example5.invalid/page5\n"
+    "2\t6\thttps://example6.invalid/page6\n"
+    "2\t7\thttps://example7.invalid/page7\n"
+    "2\t8\thttps://example8.invalid/page8\n"
+    "2\t9\thttps://example9.invalid/page9\n"
+    "2\t10\thttps://example10.invalid/page10\n"
+    "2\t11\thttps://example11.invalid/page11\n"
+    "2\t12\tfavorites://\n"
+)
+
+UCPRESS_URL = ("https://online.ucpress.edu/ncm/article-abstract/50/1/54/218886/"
+               "Fatigued-Voices-and-Vocal-Health-in-fine-secolo?redirectedFrom=fulltext")
+
+# What the pre-fix script actually emitted, recorded from the same Safari:
+# `tab` bound to Safari's tab class and stringified to the literal word.
+BROKEN_TAB_LISTING = (
+    "1tab1tabhttps://example1.invalid/page1\n"
+    f"1tab12tab{UCPRESS_URL}\n"
+)
+
 
 class _Osa:
-    """Canned osascript results, keyed by what the script is asking.
+    """Canned osascript results, keyed by what the script is asking."""
 
-    `tabs` is [(window, tab, url)]; `running` and the two refusal switches
-    select which of the distinguishable failures to simulate.
-    """
-
-    def __init__(self, running=True, tabs=(), refuse_events=False,
-                 refuse_js=False, capture=""):
+    def __init__(self, running=True, listing=SAFARI_TAB_LISTING,
+                 refuse_events=False, refuse_js=False, capture=""):
         self.running = running
-        self.tabs = tabs
+        self.listing = listing
         self.refuse_events = refuse_events
         self.refuse_js = refuse_js
         self.capture = capture
@@ -241,9 +297,10 @@ class _Osa:
         if "is running" in script:
             return self._R(0, "true" if self.running else "false")
         if "repeat with w in windows" in script:
-            out = "".join(f"{w}\t{t}\t{u}\n" for w, t, u in self.tabs)
-            return self._R(0, out)
-        # the JS capture
+            # Chrome is not running in these fixtures; only Safari answers.
+            if 'application "Safari"' not in script:
+                return self._R(0, "")
+            return self._R(0, self.listing)
         if self.refuse_js:
             return self._R(1, "", self._REFUSAL)
         return self._R(0, self.capture)
@@ -253,15 +310,85 @@ def _osa(**kw):
     return _patched(web_source.subprocess, "run", _Osa(**kw))
 
 
-def _probe(url=BOOKMARK_URL):
+def _probe(url=UCPRESS_URL):
     lines = []
     html, app, summary = web_source.browser_tab_dom(url, log=lines.append)
     return html, app, summary, "\n".join(lines)
 
 
+def test_applescript_does_not_use_tab_inside_the_tell_block():
+    # The root cause, asserted directly on the generated script rather than
+    # only through its output: `tab` and `linefeed` must be bound BEFORE
+    # `tell application`, where no app terminology can shadow them.
+    scripts = []
+
+    def spy(script, timeout=15):
+        scripts.append(script)
+        return web_source.OSA_OK, "true" if "is running" in script else ""
+
+    with _patched(web_source, "_osascript", spy):
+        web_source._list_tabs("Safari")
+
+    listing = [s for s in scripts if "repeat with w in windows" in s][0]
+    before, _, after = listing.partition("tell application")
+    assert "set d to tab" in before, listing
+    assert " & tab & " not in after, "bare `tab` is shadowed by Safari's tab class"
+    return True
+
+
+def test_browser_probe_finds_the_target_in_the_real_listing():
+    # The regression test for the terminology collision: against Safari's
+    # actual output the target must be found - at window 1 tab 12, past ten
+    # non-matching tabs, with a second window holding 11 of the same URLs.
+    with _osa(capture="<html>ok</html>"):
+        html, app, summary, log = _probe()
+    assert html == "<html>ok</html>", html
+    assert app == "Safari"
+    assert "matched window 1 tab 12" in log, log
+    return True
+
+
+def test_broken_listing_is_reported_as_a_parse_error_not_as_no_tabs():
+    # The pre-fix output must never again present itself as an empty browser.
+    # This is the exact string that produced "no tabs open" and "0 tab(s)
+    # examined" against a Safari with 26 tabs open.
+    with _osa(listing=BROKEN_TAB_LISTING):
+        html, app, summary, log = _probe()
+    assert html is None
+    assert "could not parse" in summary, summary
+    assert "no tabs open" not in log, log
+    assert "no matching tab" not in summary, summary
+    return True
+
+
+def test_non_http_scheme_does_not_break_the_listing():
+    # favorites:// is the last tab of the last window in the real capture.
+    # A parser that assumed every entry is an http URL would drop it, or
+    # worse, abandon the rest - so assert the full count survives it.
+    with _osa(capture="<html>ok</html>"):
+        tabs, status, detail = web_source._list_tabs("Safari")
+    assert status == web_source.OSA_OK, (status, detail)
+    assert len(tabs) == 26, len(tabs)
+    assert (2, 12, "favorites://") in tabs, tabs[-3:]
+    return True
+
+
+def test_duplicate_windows_do_not_confuse_the_index():
+    # 11 URLs are open in both windows. The reported (window, tab) pair must
+    # be the one actually matched, not the last seen or a window-1 default.
+    dup = "https://example11.invalid/page11"          # window 1 tab 11, window 2 tab 11
+    with _osa(capture="<html>ok</html>"):
+        lines = []
+        html, app, summary = web_source.browser_tab_dom(dup, log=lines.append)
+    assert html == "<html>ok</html>"
+    # First match in enumeration order - window 1, not window 2.
+    assert "matched window 1 tab 11" in "\n".join(lines), lines
+    return True
+
+
 def test_browser_probe_reports_apple_events_refusal():
-    # State 1 of 3. Previously indistinguishable from "no tab" - this is the
-    # conflation that made a single failure take three rounds to diagnose.
+    # State 1. Previously indistinguishable from "no tab" - the conflation
+    # that made a single failure take three rounds to diagnose.
     with _osa(refuse_events=True):
         html, app, summary, log = _probe()
     assert html is None and app is None
@@ -272,7 +399,7 @@ def test_browser_probe_reports_apple_events_refusal():
 
 
 def test_browser_probe_reports_not_running():
-    # State 2 of 3.
+    # State 2.
     with _osa(running=False):
         html, app, summary, log = _probe()
     assert html is None
@@ -282,47 +409,35 @@ def test_browser_probe_reports_not_running():
 
 
 def test_browser_probe_names_the_tabs_it_saw_on_no_match():
-    # State 3 of 3, and the diagnostic that makes a matching bug visible:
-    # without the tab URLs there is no way to tell "the tab wasn't open"
-    # from "the tab was open and matching is wrong."
-    tabs = (
-        (1, 1, "https://academic.oup.com/jaac/doi/10.1093/jaac/OTHER/999?utm_source=x"),
-        (1, 2, "https://example.com/unrelated"),
-    )
-    with _osa(tabs=tabs):
-        html, app, summary, log = _probe()
+    # State 3, and the diagnostic that makes a matching bug visible: without
+    # the tab URLs there is no way to tell "the tab wasn't open" from "the
+    # tab was open and matching is wrong." Asked for a URL on the same host
+    # as the target, so the same-host section is exercised too.
+    other = "https://online.ucpress.edu/ncm/article/99/9/9/999999/Some-Other-Article"
+    with _osa():
+        lines = []
+        html, app, summary = web_source.browser_tab_dom(other, log=lines.append)
+    log = "\n".join(lines)
     assert html is None
     assert "no matching tab" in summary, summary
-    # Same-host tabs are named in full, and cleaned (utm_source stripped).
-    assert "10.1093/jaac/OTHER/999" in log, log
-    assert "utm_source" not in log, log
-    assert "academic.oup.com" in log, log
-    # The off-host tab is named too, under its own heading.
-    assert "example.com/unrelated" in log, log
+    assert "26 tab(s) examined" in summary, summary
+    # The real target is on the same host, so it is named in full.
+    assert "Fatigued-Voices" in log, log
+    assert "online.ucpress.edu" in log, log
+    # Off-host tabs are named too, under their own heading, and capped.
+    assert "example1.invalid" in log, log
     return True
 
 
 def test_browser_probe_distinguishes_js_refusal_from_missing_tab():
     # A tab WAS found; only the separate "Allow JavaScript from Apple Events"
     # switch refused. Reported as its own state, not as "no matching tab".
-    with _osa(tabs=((1, 1, BOOKMARK_URL),), refuse_js=True):
+    with _osa(refuse_js=True):
         html, app, summary, log = _probe()
     assert html is None
     assert "JavaScript from Apple Events refused" in summary, summary
     assert "no matching tab" not in summary, summary
-    assert "matched window 1 tab 1" in log, log
-    return True
-
-
-def test_browser_probe_captures_a_matching_tab():
-    # The success path, so the four failure tests above can't pass trivially
-    # on a probe that never works at all.
-    with _osa(tabs=((2, 3, BOOKMARK_URL + "?utm_campaign=news"),), capture="<html>ok</html>"):
-        html, app, summary, log = _probe()
-    assert html == "<html>ok</html>", html
-    assert app == "Safari"
-    assert "match" in summary, summary
-    assert "matched window 2 tab 3" in log, log
+    assert "matched window 1 tab 12" in log, log
     return True
 
 
@@ -585,11 +700,15 @@ def test_ordinary_fetch_success_does_not_touch_fallbacks():
 
 
 TESTS = [
+    test_applescript_does_not_use_tab_inside_the_tell_block,
+    test_browser_probe_finds_the_target_in_the_real_listing,
+    test_broken_listing_is_reported_as_a_parse_error_not_as_no_tabs,
+    test_non_http_scheme_does_not_break_the_listing,
+    test_duplicate_windows_do_not_confuse_the_index,
     test_browser_probe_reports_apple_events_refusal,
     test_browser_probe_reports_not_running,
     test_browser_probe_names_the_tabs_it_saw_on_no_match,
     test_browser_probe_distinguishes_js_refusal_from_missing_tab,
-    test_browser_probe_captures_a_matching_tab,
     test_browser_challenge_markup_produces_amber_entry,
     test_browser_thin_dom_produces_amber_entry,
     test_browser_genuine_article_succeeds,

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -602,11 +602,29 @@ excerpt's text won't (e.g. an embedded Author field):
             if stripped:
                 self._log(f"   Stripped disallowed field(s): {', '.join(stripped)}", 'warning')
 
+            needs_color = False
             if self.config.get('enrich_missing_fields', True):
                 bibtex_entry = self.enrich_entry(bibtex_entry, content)
                 bibtex_entry, needs_color = self.verify_and_flag_recollection(bibtex_entry, content)
-                if needs_color:
-                    bibtex_entry = "% NEEDS_COLOR_FLAG\n" + bibtex_entry
+
+            # content.amber is web_source.py's plausibility check flagging a
+            # source that's genuine but thin or sparse (no Author/Doi/
+            # PublicationDate beyond Urldate, or a short body) - not wrong,
+            # just worth a glance. Folded into the same needs_color signal
+            # a recollection-audit failure uses, but with its own persistent
+            # "% AMBER: ..." comment (see save_entry): needs_color alone
+            # only ever reaches BibDesk's own color for a PDF with
+            # autofile_bibdesk on, and a .webloc source - the only kind
+            # web_source.py produces - is never fileable (see save_entry),
+            # so without a comment the flag would otherwise vanish into a
+            # stderr warning nobody reads after the fact.
+            if content.amber:
+                needs_color = True
+                self._log(f"   ⚠️  Thin/sparse source ({content.amber_reason}) - flagging for review", 'warning')
+                bibtex_entry = f"% AMBER: {content.amber_reason}\n" + bibtex_entry
+
+            if needs_color:
+                bibtex_entry = "% NEEDS_COLOR_FLAG\n" + bibtex_entry
 
             bibtex_entry = f"% Source: {content.label} ({content.url or path.name})\n" + bibtex_entry
 
@@ -1030,10 +1048,16 @@ BibLaTeX entry, with no additional commentary."""
             self._log("   ⚠️  pyobjc not available, skipping bdsk-file-1", 'warning')
             return entry
 
-    # Amber/orange - flags a publication whose entry contains at least one
-    # field Claude filled in from its own background knowledge of the work
-    # rather than the given source text/metadata, and that CrossRef/Scholar
-    # could neither confirm nor refute (the work wasn't found in either).
+    # Amber/orange - flags a publication for two distinct reasons, both
+    # "produced, but worth a human glance": (1) the entry contains at least
+    # one field Claude filled in from its own background knowledge of the
+    # work rather than the given source text/metadata, and that CrossRef/
+    # Scholar could neither confirm nor refute (see verify_and_flag_
+    # recollection); (2) the source itself is genuine but thin or sparse -
+    # web_source.py's content-plausibility check (see extract_bibtex's use
+    # of content.amber). Only ever reaches this BibDesk color for a PDF with
+    # autofile_bibdesk on; see save_entry's "% AMBER: ..." comment for the
+    # case that doesn't (every .webloc source, among others).
     UNVERIFIED_COLOR = "{65535, 40000, 0, 65535}"
 
     def _save_via_bibdesk(self, entry, bib_path, needs_color=False):
@@ -1191,7 +1215,7 @@ end tell'''
         # first and re-attach it once cleaning is done (outermost marker -
         # see the prepend order in extract_bibtex).
         source_comment = ''
-        marker_match = re.match(r'(%\s*Source:\b[^\n]*\n)', bibtex_entry)
+        marker_match = re.match(r'(%\s*Source\b:[^\n]*\n)', bibtex_entry)
         if marker_match:
             source_comment = marker_match.group(1)
             bibtex_entry = bibtex_entry[marker_match.end():]
@@ -1205,6 +1229,19 @@ end tell'''
         marker_match = re.match(r'(%\s*NEEDS_COLOR_FLAG\s*\n)', bibtex_entry)
         if marker_match:
             needs_color = True
+            bibtex_entry = bibtex_entry[marker_match.end():]
+
+        # extract_bibtex() prepends a "% AMBER: ..." comment when
+        # content.amber is set (web_source.py's plausibility check: a
+        # genuine but thin/sparse source). Unlike NEEDS_COLOR_FLAG, this one
+        # IS re-attached below: a .webloc source is never fileable (see the
+        # is_fileable_source check further down), so it never reaches
+        # BibDesk's own color, and this comment is the only place the flag
+        # survives into the saved .bib text.
+        amber_comment = ''
+        marker_match = re.match(r'(%\s*AMBER\b:[^\n]*\n)', bibtex_entry)
+        if marker_match:
+            amber_comment = marker_match.group(1)
             bibtex_entry = bibtex_entry[marker_match.end():]
 
         # enrich_entry() prepends a "% Sources -- ..." comment recording field
@@ -1234,6 +1271,8 @@ end tell'''
 
         if sources_comment:
             entry = sources_comment + entry
+        if amber_comment:
+            entry = amber_comment + entry
         if source_comment:
             entry = source_comment + entry
 
@@ -1269,7 +1308,9 @@ end tell'''
 
         if needs_color:
             reason = "not a PDF source" if not is_fileable_source else "autofile_bibdesk to apply"
-            self._log(f"   ⚠️  Unverified recollection-based field(s) - color flag needs {reason}", 'warning')
+            self._log(f"   ⚠️  Unverified field(s) or a thin source - color flag needs {reason}"
+                      + (" (see the % AMBER comment in the saved entry)" if amber_comment else ""),
+                      'warning')
 
         output_path = Path(self.config['main_bib_file']).expanduser()
         if not output_path.exists():

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -610,14 +610,13 @@ excerpt's text won't (e.g. an embedded Author field):
             # content.amber is web_source.py's plausibility check flagging a
             # source that's genuine but thin or sparse (no Author/Doi/
             # PublicationDate beyond Urldate, or a short body) - not wrong,
-            # just worth a glance. Folded into the same needs_color signal
-            # a recollection-audit failure uses, but with its own persistent
-            # "% AMBER: ..." comment (see save_entry): needs_color alone
-            # only ever reaches BibDesk's own color for a PDF with
-            # autofile_bibdesk on, and a .webloc source - the only kind
-            # web_source.py produces - is never fileable (see save_entry),
-            # so without a comment the flag would otherwise vanish into a
-            # stderr warning nobody reads after the fact.
+            # just worth a glance. Folded into the same needs_color signal a
+            # recollection-audit failure uses, so it reaches BibDesk's review
+            # color by exactly the path a PDF's review state does. The
+            # additional "% AMBER: ..." comment carries the same flag on the
+            # other branch, where entries are appended as text and no color
+            # is possible; each survives where the other cannot (see
+            # save_entry).
             if content.amber:
                 needs_color = True
                 self._log(f"   ⚠️  Thin/sparse source ({content.amber_reason}) - flagging for review", 'warning')
@@ -1055,13 +1054,21 @@ BibLaTeX entry, with no additional commentary."""
     # Scholar could neither confirm nor refute (see verify_and_flag_
     # recollection); (2) the source itself is genuine but thin or sparse -
     # web_source.py's content-plausibility check (see extract_bibtex's use
-    # of content.amber). Only ever reaches this BibDesk color for a PDF with
-    # autofile_bibdesk on; see save_entry's "% AMBER: ..." comment for the
-    # case that doesn't (every .webloc source, among others).
+    # of content.amber). Applied whenever autofile_bibdesk is on, whatever
+    # the source type; with it off, entries are appended as text and the
+    # flag travels as save_entry's "% AMBER: ..." comment instead.
     UNVERIFIED_COLOR = "{65535, 40000, 0, 65535}"
 
-    def _save_via_bibdesk(self, entry, bib_path, needs_color=False):
-        """Open the staging file in BibDesk (if needed), import the entry, and auto-file it.
+    def _save_via_bibdesk(self, entry, bib_path, needs_color=False, auto_file=True):
+        """Open the staging file in BibDesk (if needed), import the entry, and
+        (for a source with a document behind it) auto-file that document.
+
+        `auto_file=False` for a source that has no document to file - a
+        .webloc bookmarks a webpage, so there is nothing for BibDesk to
+        rename and move. Everything else here still applies to it: the import
+        and, above all, the review color, which is the only form the amber
+        flag can take once BibDesk owns the file (its importer re-serializes
+        the entry and discards every % comment).
 
         Uses a temp file for the import to avoid AppleScript quoting issues.
         Raises RuntimeError on failure so the caller can log and fall through.
@@ -1076,6 +1083,7 @@ BibLaTeX entry, with no additional commentary."""
             tmp_path = tmp.name
 
         color_line = f"set color of pub to {self.UNVERIFIED_COLOR}\n    " if needs_color else ""
+        file_line = "auto file pub" if auto_file else ""
         script = f'''
 tell application "BibDesk"
     set bibPath to "{bib_path}"
@@ -1093,7 +1101,7 @@ tell application "BibDesk"
     if thePubs is missing value or (count of thePubs) is 0 then return "import failed"
     set pub to item 1 of thePubs
     set cite key of pub to (generated cite key of pub)
-    {color_line}auto file pub
+    {color_line}{file_line}
     return "ok"
 end tell'''
 
@@ -1104,7 +1112,8 @@ end tell'''
             )
             output = result.stdout.strip()
             if output == "ok":
-                self._log("   ✓ Imported into BibDesk and auto-filed", 'success')
+                self._log("   ✓ Imported into BibDesk" + (" and auto-filed" if auto_file else ""),
+                          'success')
             else:
                 raise RuntimeError(output or result.stderr.strip())
         except RuntimeError:
@@ -1302,27 +1311,41 @@ end tell'''
         # Attach a BibDesk file bookmark and auto-file the linked document -
         # PDF sources only. A .webloc is just a bookmark to a webpage used to
         # extract bibliographic data; it has no document worth filing into
-        # BibDesk's library, so it's left untouched (not bookmarked, not moved).
-        is_fileable_source = pdf_path.suffix.lower() == '.pdf'
-        if is_fileable_source:
+        # BibDesk's library, so it is neither bookmarked nor moved.
+        #
+        # Having a document to file is NOT the same question as belonging in
+        # BibDesk, though, and conflating the two is what left web-sourced
+        # entries with no review flag at all: under autofile_bibdesk the
+        # importer re-serializes each entry and discards every % comment, so
+        # the color is the only surviving form of the flag - and a .webloc
+        # entry, excluded from the import path entirely, could not be colored
+        # and could not keep its comment either. It goes through the import
+        # like any other entry now; only `auto file` (which needs a document)
+        # is withheld.
+        has_document = pdf_path.suffix.lower() == '.pdf'
+        if has_document:
             entry = self.add_bdsk_bookmark(entry, pdf_path)
 
-        if is_fileable_source and self.config.get('autofile_bibdesk', False):
+        if self.config.get('autofile_bibdesk', False):
             output_path = Path(self.config['main_bib_file']).expanduser()
             if not output_path.exists():
                 output_path.parent.mkdir(parents=True, exist_ok=True)
                 output_path.touch()
             bib_path = str(output_path.resolve())
             try:
-                self._save_via_bibdesk(entry, bib_path, needs_color=needs_color)
+                self._save_via_bibdesk(entry, bib_path, needs_color=needs_color,
+                                        auto_file=has_document)
                 return True
             except RuntimeError as e:
                 self._log(f"   ⚠️  BibDesk import failed: {e}", 'warning')
                 return False
 
+        # Plain-text append: no BibDesk, so no color is possible - but here
+        # the % comments do survive into the file, which is what the AMBER
+        # comment is for. The two carriers are complementary, not redundant.
         if needs_color:
-            reason = "not a PDF source" if not is_fileable_source else "autofile_bibdesk to apply"
-            self._log(f"   ⚠️  Unverified field(s) or a thin source - color flag needs {reason}"
+            self._log("   ⚠️  Unverified field(s) or a thin source - color flag needs "
+                      "autofile_bibdesk to apply"
                       + (" (see the % AMBER comment in the saved entry)" if amber_comment else ""),
                       'warning')
 

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -1214,6 +1214,20 @@ end tell'''
         # clean_bibtex() strips anything before the first '@', so pull it out
         # first and re-attach it once cleaning is done (outermost marker -
         # see the prepend order in extract_bibtex).
+        #
+        # Until fixed here, this pattern's \b sat right after the literal
+        # ':' (`Source:\b`) - impossible, since neither side of that
+        # position is a word character - so it never matched anything.
+        # Because % Source: is always the outermost/first line and re.match
+        # anchors at position 0, that didn't just drop this comment: with
+        # bibtex_entry left unstripped, EVERY marker regex below it also
+        # failed to match against the unrelated text still sitting at
+        # position 0, for every entry this method ever saved - PDF or
+        # .webloc alike. needs_color could never become True by this path
+        # before this fix, so BibDesk's amber coloring (UNVERIFIED_COLOR)
+        # was inert from the day it was introduced, not merely blind to
+        # .webloc sources as the comments below (written after this fix)
+        # describe for the design going forward.
         source_comment = ''
         marker_match = re.match(r'(%\s*Source\b:[^\n]*\n)', bibtex_entry)
         if marker_match:

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -559,8 +559,17 @@ excerpt's text won't (e.g. an embedded Author field):
         if suffix == '.pdf':
             kwargs = self._pdf_extractor_kwargs(path)
         elif suffix == '.webloc':
-            # For the CrossRef fallback when the page is behind a bot wall.
-            kwargs = {'crossref_email': self.config.get('crossref_email')}
+            # crossref_email is for the CrossRef fallback when the page is
+            # behind a bot wall. `log` routes web_source's own path reporting
+            # (which source produced the text, why each rejected one was
+            # rejected, which browser tabs were examined) through _log, so it
+            # reaches the progress window and not only stderr - the windowed
+            # run shows _log messages exclusively, so a bare print there is
+            # invisible exactly when a .webloc is hardest to diagnose.
+            kwargs = {
+                'crossref_email': self.config.get('crossref_email'),
+                'log': lambda msg: self._log(f"   {msg}", 'info'),
+            }
         else:
             kwargs = {}
         content = extractor(path, **kwargs)

--- a/src/extract_pages.py
+++ b/src/extract_pages.py
@@ -28,6 +28,12 @@ class SourceContent:
     metadata: dict = field(default_factory=dict)
     label: str = "PDF"          # human-readable source kind, used once in build_prompt
     url: Optional[str] = None   # set only when the source has a canonical access URL
+    # Set by web_source.py's plausibility check: the content genuinely came
+    # from the requested URL but is thin or sparse (missing metadata, short
+    # body) - not wrong, just worth a human glance. biblio_agent.py folds
+    # this into the existing "needs_color" (BibDesk amber) mechanism.
+    amber: bool = False
+    amber_reason: Optional[str] = None
 
 
 def extract_pdf_metadata(pdf_path):

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -12,6 +12,7 @@ import json
 import plistlib
 import re
 import subprocess
+import sys
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
 
@@ -454,12 +455,149 @@ def _page_text(soup):
     return snap_to_sentence_end(text, TEXT_WORD_BUDGET, from_end=False)
 
 
+def _content_from_html(html, source_url, label):
+    """Parse raw page HTML into a SourceContent - the same construction
+    whether the HTML came from a live HTTP fetch or a captured browser tab,
+    so the plausibility check below runs identically over both. Returns the
+    soup alongside the content, since the caller needs it again to check the
+    page's own canonical link / og:url."""
+    soup = BeautifulSoup(html, 'html.parser')
+    # Metadata before text: _page_text() decomposes every <script> tag
+    # (deliberately, to keep chrome out of the body text), which destroys
+    # the JSON-LD block _page_metadata() reads from.
+    metadata = _page_metadata(soup)
+    text = _page_text(soup)
+    return SourceContent(text=text, metadata=metadata, label=label,
+                          url=clean_url(source_url)), soup
+
+
+# ── Content plausibility ─────────────────────────────────────────────────
+#
+# Classifying the *failure* (is_bot_challenge, above) only ever catches a
+# gatekeeper that answers with an error status. DataDome, Kasada, consent
+# gates and login walls commonly answer 200 with an interstitial instead -
+# there is no error to classify, so the only thing that tells it apart from
+# the article is what actually came back. Applied identically to every path
+# that can produce a SourceContent (fetch, browser tab, CrossRef), so none
+# of the three can hand the model a confident wrong entry.
+
+_IDENTIFYING_FIELDS = ('Author', 'Doi', 'PublicationDate')
+
+# Provisional floor pending #16's own thin-yield threshold; borrowed from
+# extract_pages.py's OCR-retry threshold (also 100 words), the closest
+# existing precedent in this codebase for "too little text to trust." HTML-
+# derived content only (fetch, browser tab) - a CrossRef record isn't a DOM
+# that can still be loading, so it has no length to check; its guard is the
+# identifying-metadata check below instead (see _content_plausible).
+MIN_BODY_WORDS = 100
+
+
+def _url_matches(a, b):
+    return clean_url(a).rstrip('/') == clean_url(b).rstrip('/')
+
+
+def _url_correspondence(candidate_urls, soup, metadata):
+    """(ok, reason) - whether at least one of the page's own self-identifying
+    signals (canonical link, og:url, embedded Doi) points back at one of the
+    URLs this content might legitimately be found at.
+
+    Every present signal is checked against every candidate URL, rather than
+    stopping at the first signal found or requiring all of them to agree:
+    `candidate_urls` normally holds both the bookmarked .webloc URL and, for
+    a live fetch, the URL requests.get() actually landed on after following
+    redirects - a doi.org bookmark resolves to the publisher's own URL, whose
+    canonical link then names the publisher URL rather than the redirector,
+    while its embedded DOI still matches the original bookmark. Requiring
+    the first signal present to match would reject that page over a mismatch
+    that was never a contradiction.
+
+    No signal present at all is neither confirmed nor contradicted, so it
+    passes: plenty of legitimate pages carry none of the three, and this
+    check exists to catch a genuine *contradiction* (a login wall's
+    canonical link pointing at the login page, a captured tab that has
+    navigated elsewhere) - a page too thin to carry any of these tags is
+    already caught by the identifying-metadata and length checks.
+    """
+    signals = []
+    if soup is not None:
+        canonical = soup.find('link', rel='canonical')
+        href = canonical.get('href') if canonical else None
+        if href and href.startswith('http'):
+            signals.append(('canonical link', href))
+        og_url = soup.find('meta', attrs={'property': 'og:url'})
+        content = og_url.get('content') if og_url else None
+        if content and content.startswith('http'):
+            signals.append(('og:url', content))
+    doi = metadata.get('Doi')
+    if doi:
+        signals.append(('embedded Doi', doi))
+
+    if not signals:
+        return True, None
+
+    for label, value in signals:
+        for candidate in candidate_urls:
+            if label == 'embedded Doi':
+                if value.lower() in candidate.lower():
+                    return True, None
+            elif _url_matches(candidate, value):
+                return True, None
+    described = '; '.join(f"{label} = {value}" for label, value in signals)
+    return False, f"none of its self-identifying signals match the requested URL ({described})"
+
+
+def _content_plausible(content, candidate_urls, soup=None):
+    """(is_plausible, reason) - whether `content` genuinely describes the
+    bookmarked work, applied the same way regardless of which path produced
+    it. `candidate_urls` is every URL the content may legitimately declare
+    itself as (see _url_correspondence); `soup` is the parsed page for the
+    fetch/browser-tab paths, or None for CrossRef, which has no page to read
+    a canonical link or og:url from.
+    """
+    metadata = content.metadata
+    if not metadata.get('Title'):
+        return False, "no Title in the extracted metadata"
+    if not any(metadata.get(f) for f in _IDENTIFYING_FIELDS):
+        return False, "Title but no Author/Doi/PublicationDate - looks like an interstitial"
+    ok, reason = _url_correspondence(candidate_urls, soup, metadata)
+    if not ok:
+        return False, reason
+    if soup is not None and len(split_into_words(content.text)) < MIN_BODY_WORDS:
+        return False, f"body text under {MIN_BODY_WORDS} words - looks like a page still loading"
+    return True, None
+
+
+def _log_source(chosen, url):
+    """State which path produced the text for `url` - printed unconditionally
+    (matching extract_pages.py's OCR-retry warnings) so this is visible in
+    normal output with nothing to instrument."""
+    print(f"   Source: {chosen} for {url}", file=sys.stderr)
+
+
+def _log_rejected(path_label, reason, next_step):
+    print(f"   ⚠️  {path_label} rejected ({reason}); trying {next_step}", file=sys.stderr)
+
+
 def extract_webloc(webloc_path, timeout=20, crossref_email=None):
     """
     Extract a .webloc bookmark's target page as a SourceContent.
 
-    Where the publisher answers a bot challenge rather than the page, falls
-    back to the CrossRef record for the DOI in the URL's own path.
+    Three paths are tried in order - an ordinary fetch, a browser tab already
+    open on the bookmarked URL, and the CrossRef record for a DOI in the
+    URL's own path - and every one of them is checked for plausibility
+    before being trusted (see _content_plausible): the metadata must
+    identify a work, and the content must correspond to the requested URL.
+    A path that fails the check is treated exactly like a path that produced
+    nothing at all, and the next one is tried.
+
+    The browser tab is tried on any failure of the fetch (a non-2xx status,
+    or a 200 that failed the plausibility check) - a tab rendering the page
+    is proof of life no HTTP response can provide, whatever its status code.
+    CrossRef stays gated on a classified bot challenge (is_bot_challenge):
+    unlike the browser path it has no page to check against, only a DOI
+    mined from the URL, so trying it on every failure would risk filing a
+    record for a URL that's simply dead (a plain 404) - the original
+    rationale for that gate, unchanged here.
 
     Returns:
         SourceContent on success, or a string starting with "Error:" on failure.
@@ -482,50 +620,49 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
     except requests.RequestException as e:
         return f"Error: Could not fetch {url}: {e}"
 
-    # A challenge is the one failure worth routing around: the work exists and
-    # is citable, only this client is unwelcome. Every other non-2xx is left to
-    # fail loudly - a 404 masked by a CrossRef hit would file an entry whose
-    # Url points at a dead page, which is worse than a reported failure.
-    if not response.ok:
-        if not is_bot_challenge(response):
-            return f"Error: Could not fetch {url}: HTTP {response.status_code}"
+    challenge = is_bot_challenge(response)
+    rejected = []  # (path label, reason), in the order tried
 
-        # A browser already holding the session and a genuine fingerprint
-        # beats a DOI-only CrossRef record when the page is still open in a
-        # tab; falls through untouched below when it isn't.
-        html, browser_app = browser_tab_dom(url)
-        if html:
-            soup = BeautifulSoup(html, 'html.parser')
-            # Metadata before text: _page_text() decomposes <script> tags,
-            # which destroys the JSON-LD block _page_metadata() reads from -
-            # keyword arguments evaluate left to right regardless of the
-            # order they're written in, so text=/metadata=/... below would
-            # silently lose Author/PublicationDate from JSON-LD-only pages.
-            metadata = _page_metadata(soup)
-            text = _page_text(soup)
-            return SourceContent(
-                text=text,
-                metadata=metadata,
-                label=f"webpage (via {browser_app} tab)",
-                url=clean_url(url),
-            )
+    if response.ok:
+        content, soup = _content_from_html(response.text, response.url, "webpage")
+        ok, reason = _content_plausible(content, {url, response.url}, soup)
+        if ok:
+            _log_source("fetch", url)
+            return content
+        rejected.append(("fetch", reason))
+        _log_rejected("fetch", reason, "a browser tab")
 
+    # Tried on ANY failure - non-2xx status or a 200 that didn't pass the
+    # plausibility check - not only a classified bot challenge: a browser
+    # already holding the session and a genuine TLS fingerprint beats
+    # whatever the plain HTTP client got back, and DataDome/Kasada/consent-
+    # wall interstitials never trip is_bot_challenge at all.
+    html, browser_app = browser_tab_dom(url)
+    if html:
+        label = f"browser tab ({browser_app})"
+        content, soup = _content_from_html(html, url, f"webpage (via {browser_app} tab)")
+        ok, reason = _content_plausible(content, {url}, soup)
+        if ok:
+            _log_source(label, url)
+            return content
+        rejected.append((label, reason))
+        _log_rejected(label, reason, "CrossRef" if challenge else "reporting failure")
+
+    if challenge:
         fallback = crossref_fallback(url, crossref_email)
         if fallback:
-            return fallback
+            ok, reason = _content_plausible(fallback, {url}, soup=None)
+            if ok:
+                _log_source("CrossRef", url)
+                return fallback
+            rejected.append(("CrossRef", reason))
+            _log_rejected("CrossRef", reason, "reporting failure")
+
+    _log_source("failure", url)
+    if rejected:
+        detail = '; '.join(f"{path}: {reason}" for path, reason in rejected)
+        return f"Error: {url} yielded no plausible source ({detail})"
+    if challenge:
         return (f"Error: {url} is behind a bot challenge (HTTP "
                 f"{response.status_code}) and its URL carries no DOI to fall back on")
-
-    soup = BeautifulSoup(response.text, 'html.parser')
-
-    # Metadata before text - see the identical comment in the browser-DOM
-    # branch above.
-    metadata = _page_metadata(soup)
-    text = _page_text(soup)
-    return SourceContent(
-        text=text,
-        metadata=metadata,
-        label="webpage",
-        # Final URL after any redirects (e.g. DOI resolvers), minus tracking.
-        url=clean_url(response.url),
-    )
+    return f"Error: Could not fetch {url}: HTTP {response.status_code}"

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -332,21 +332,44 @@ def _list_tabs(app_name):
     if not running:
         return [], BROWSER_NOT_RUNNING, ''
 
+    # `tab` and `linefeed` are bound OUTSIDE the tell block on purpose. Inside
+    # `tell application "Safari"` (and Chrome, whose dictionary also defines
+    # one) the word `tab` resolves to the application's own `tab` class, not
+    # to AppleScript's tab-character constant - so the delimiter came out as
+    # the literal three-letter text "tab":
+    #
+    #     1tab1tabhttps://example.com/...
+    #
+    # which split('\t') could not divide into three fields, so every line was
+    # discarded and the browser reported zero tabs open against a Safari with
+    # 26 of them. Verified by hand against the running Safari, before and
+    # after. Binding the constants first, where no application terminology is
+    # in scope, is what makes them mean what they say.
+    #
+    # `URL of t` is read through a try: a Start Page or Tab Group tab can
+    # answer `missing value`, and concatenating that aborts the whole script -
+    # one such tab would otherwise cost the entire listing.
     script = f'''
+    set d to tab
+    set lf to linefeed
+    set out to ""
     tell application "{app_name}"
         if (count of windows) is 0 then return ""
-        set out to ""
         set wIdx to 0
         repeat with w in windows
             set wIdx to wIdx + 1
             set tIdx to 0
             repeat with t in tabs of w
                 set tIdx to tIdx + 1
-                set out to out & wIdx & tab & tIdx & tab & (URL of t) & linefeed
+                set u to ""
+                try
+                    set u to (URL of t) as text
+                end try
+                set out to out & wIdx & d & tIdx & d & u & lf
             end repeat
         end repeat
-        return out
     end tell
+    return out
     '''
     status, output = _osascript(script)
     if status == OSA_REFUSED:
@@ -356,15 +379,27 @@ def _list_tabs(app_name):
     if not output:
         return [], BROWSER_NO_WINDOWS, ''
 
-    tabs = []
+    tabs, unparsed = [], []
     for line in output.splitlines():
+        if not line.strip():
+            continue
         parts = line.split('\t')
         if len(parts) != 3:
+            unparsed.append(line)
             continue
         try:
             tabs.append((int(parts[0]), int(parts[1]), parts[2]))
         except ValueError:
-            continue
+            unparsed.append(line)
+
+    # Output arrived but nothing in it parsed: the script ran and the format
+    # is not what this expects. Reported as an error naming the first line
+    # rather than as an empty tab list - silently dropping unparsable lines
+    # is what let the `tab` terminology collision above present itself as
+    # "no tabs open" against a browser that had 26.
+    if unparsed and not tabs:
+        return [], BROWSER_ERROR, (f"could not parse the tab listing "
+                                    f"({len(unparsed)} line(s)); first: {unparsed[0][:120]!r}")
     return tabs, OSA_OK, ''
 
 

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -492,13 +492,33 @@ def browser_tab_dom(url, log=None):
             log(f"  {app_name}: {status}")
             continue
 
-        match = None
+        # Exact first, identity only as a fallback. A publisher serves one
+        # work at several addresses (/article/ vs /article-abstract/), and
+        # clean_url() already absorbs the query-parameter half of that, which
+        # is why a ?redirectedFrom bookmark matches its tab; the path half it
+        # cannot reach, so _url_matches - the same rule the correspondence
+        # check uses - decides that. One rule over both steps, rather than
+        # two that nearly agree.
+        #
+        # Preference order matters and is not merely tidiness: with the same
+        # article open in two forms, the tab actually asked for is the one to
+        # capture. `tabs` is already in window-then-tab order, so taking the
+        # first identity match makes the fallback deterministic too.
+        #
+        # Unlike the correspondence check, this has no backstop: capture the
+        # wrong tab and the wrong document is what gets read. Should the two
+        # sites ever need to diverge, this is the one that stays stricter.
+        exact = identity = None
         for win_idx, tab_idx, tab_url in tabs:
             if clean_url(tab_url).rstrip('/') == target:
-                match = (win_idx, tab_idx)
+                exact = (win_idx, tab_idx, tab_url)
                 break
+            if identity is None and _url_matches(url, tab_url):
+                identity = (win_idx, tab_idx, tab_url)
 
-        if not match:
+        chosen, kind = (exact, 'exact') if exact else (identity, 'identity')
+
+        if not chosen:
             outcomes.append(f"{app_name}: {BROWSER_NO_MATCH} ({len(tabs)} tab(s) examined)")
             described = _describe_tabs(tabs, url)
             log(f"  {app_name}: {described[0]}")
@@ -506,13 +526,19 @@ def browser_tab_dom(url, log=None):
                 log(f"    {line}")
             continue
 
-        html, cap_status, cap_detail = _capture_tab_dom(app_name, *match)
+        win_idx, tab_idx, tab_url = chosen
+        # An identity match names the tab's own URL: it is not the address
+        # that was asked for, so the log has to show which page was taken.
+        where = (f"window {win_idx} tab {tab_idx} ({kind} match)" if kind == 'exact'
+                 else f"window {win_idx} tab {tab_idx} ({kind} match: "
+                      f"{clean_url(tab_url).rstrip('/')})")
+
+        html, cap_status, cap_detail = _capture_tab_dom(app_name, win_idx, tab_idx)
         if html:
-            log(f"  {app_name}: matched window {match[0]} tab {match[1]}; "
-                f"captured {len(html)} characters")
-            return html, app_name, f"{app_name}: {BROWSER_MATCH}"
+            log(f"  {app_name}: matched {where}; captured {len(html)} characters")
+            return html, app_name, f"{app_name}: {BROWSER_MATCH} ({kind})"
         outcomes.append(f"{app_name}: {cap_status}" + (f" ({cap_detail})" if cap_detail else ""))
-        log(f"  {app_name}: matched window {match[0]} tab {match[1]}, but {cap_status}"
+        log(f"  {app_name}: matched {where}, but {cap_status}"
             + (f" - {cap_detail}" if cap_detail else ""))
 
     return None, None, '; '.join(outcomes)

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -529,7 +529,14 @@ def _url_correspondence(candidate_urls, soup, metadata):
         if content and content.startswith('http'):
             signals.append(('og:url', content))
     doi = metadata.get('Doi')
-    if doi:
+    # A contradiction only if some candidate URL actually advertises a DOI in
+    # its own path - most publisher URLs don't (an Oxford Academic
+    # /article/80/1/1/1234567 carries none), so the page's own citation_doi
+    # meta tag would otherwise be the only signal available and reject a
+    # perfectly ordinary article on every such URL. Absent that, the DOI is
+    # unverifiable rather than contradicted, which is the same reasoning as
+    # "no signal present" below.
+    if doi and any(doi_candidates(c) for c in candidate_urls):
         signals.append(('embedded Doi', doi))
 
     if not signals:

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -656,8 +656,85 @@ _IDENTIFYING_FIELDS = ('Author', 'Doi', 'PublicationDate')
 MIN_BODY_WORDS = 100
 
 
+# Path segments that describe the *form* a publisher serves a work in rather
+# than which work it is. A segment built entirely of these is structural and
+# identifies nothing: /article/, /article-abstract/, /advance-article-pdf/
+# and their kin all name the same underlying article. Kept as words rather
+# than whole segments so unseen combinations are covered too.
+_STRUCTURAL_PATH_WORDS = {
+    'article', 'articles', 'advance', 'abstract', 'full', 'fulltext', 'text',
+    'pdf', 'epdf', 'html', 'view', 'viewer', 'download', 'content', 'doi',
+    'lookup', 'issue', 'cover', 'search', 'results', 'citation', 'cite',
+    'supplemental', 'supplementary', 'figure', 'table', 'print', 'summary',
+}
+
+# A run of digits long enough to be a publisher's article id rather than a
+# volume, issue, page or year. Five is deliberate: it clears four-digit years,
+# which appear in many publishers' paths and would otherwise let two unrelated
+# articles from the same year look like the same work.
+_ARTICLE_ID_RE = re.compile(r'^\d{5,}$')
+
+
+def _is_structural_segment(segment):
+    parts = [p for p in segment.lower().split('-') if p]
+    return bool(parts) and all(p in _STRUCTURAL_PATH_WORDS for p in parts)
+
+
+def _identifying_segments(path):
+    """The path segments that identify *which work* a URL names.
+
+    Two kinds qualify: a long numeric article id, and a title slug. A slug
+    must carry at least two hyphens and sixteen characters and must not be
+    built purely of structural words - `music-theory` or `article-abstract`
+    would otherwise match two entirely different articles on the same host,
+    which is the one error this check exists to prevent.
+    """
+    found = set()
+    for segment in path.split('/'):
+        segment = segment.strip()
+        if not segment:
+            continue
+        if _ARTICLE_ID_RE.match(segment):
+            found.add(segment)
+        elif (len(segment) >= 16 and segment.count('-') >= 2
+                and not _is_structural_segment(segment)):
+            found.add(segment.lower())
+    return found
+
+
 def _url_matches(a, b):
-    return clean_url(a).rstrip('/') == clean_url(b).rstrip('/')
+    """True when two URLs name the same work - identity, not path equality.
+
+    A publisher serves one article at several addresses (/article/ vs
+    /article-abstract/, an `epdf` view, a `redirectedFrom` parameter), and
+    its canonical link states the definitive one. Requiring the strings to
+    agree treated the publisher's own statement about a work as evidence
+    against it, and would have rejected every Silverchair platform - Oxford
+    Academic, UC Press, most of what this feature exists for.
+
+    So: identical after cleaning, or the same host plus something that names
+    the same work - a shared DOI where both carry one, otherwise a shared
+    article id or title slug. Host alone is deliberately not enough, and
+    neither is a path difference alone: a tab showing a different article on
+    the same site must still be refused, since a false match here produces a
+    confident wrong entry, which is the failure this whole check is for.
+    """
+    clean_a, clean_b = clean_url(a).rstrip('/'), clean_url(b).rstrip('/')
+    if clean_a == clean_b:
+        return True
+
+    parts_a, parts_b = urlsplit(clean_a), urlsplit(clean_b)
+    if parts_a.netloc.lower() != parts_b.netloc.lower():
+        return False
+
+    # A DOI on both sides settles it outright, either way.
+    dois_a = {d.lower() for d in doi_candidates(clean_a)}
+    dois_b = {d.lower() for d in doi_candidates(clean_b)}
+    if dois_a and dois_b:
+        return bool(dois_a & dois_b)
+
+    ids_a, ids_b = _identifying_segments(parts_a.path), _identifying_segments(parts_b.path)
+    return bool(ids_a and ids_b and (ids_a & ids_b))
 
 
 def _url_correspondence(candidate_urls, soup, metadata):

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -11,6 +11,7 @@ SourceContent.
 import json
 import plistlib
 import re
+import subprocess
 from pathlib import Path
 from urllib.parse import urlsplit, urlunsplit, parse_qsl, urlencode
 
@@ -239,6 +240,129 @@ def crossref_fallback(url, crossref_email=None):
     return None
 
 
+# ── Browser DOM fallback (Safari / Chrome) ──────────────────────────────────
+#
+# A Cloudflare challenge keys on TLS fingerprint and JS execution, which no
+# plain HTTP client can satisfy. A browser the operator already has open
+# holds the session cookie and a genuine fingerprint, so when the bookmarked
+# URL happens to still be open in a tab, the DOM is taken from there instead
+# of fetching the page a second time. Requires a one-time setting in each
+# browser (Safari: Develop > Allow JavaScript from Apple Events; Chrome:
+# View > Developer > Allow JavaScript from Apple Events) that cannot be
+# detected in advance, so a missing permission is indistinguishable here from
+# a missing tab - both simply fall through to the existing failure path.
+
+_BROWSER_APPS = ("Safari", "Google Chrome")
+_JS_OUTER_HTML = "document.documentElement.outerHTML"
+
+
+def _osascript(script, timeout=15):
+    """Run an AppleScript snippet, returning its stdout (stripped), or None
+    on any failure: osascript missing, the script errored (no permission, no
+    such window/tab), or it ran past timeout."""
+    try:
+        result = subprocess.run(
+            ['osascript', '-e', script],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _browser_is_running(app_name):
+    """True if app_name is already running - checked so a closed browser is
+    never launched just to look for a tab that, by definition, isn't open."""
+    return _osascript(f'application "{app_name}" is running') == 'true'
+
+
+def _list_tabs(app_name):
+    """(window_index, tab_index, url) for every open tab of app_name, both
+    indices 1-based as AppleScript addresses them. Empty if the app isn't
+    running or has no windows."""
+    if not _browser_is_running(app_name):
+        return []
+    script = f'''
+    tell application "{app_name}"
+        if (count of windows) is 0 then return ""
+        set out to ""
+        set wIdx to 0
+        repeat with w in windows
+            set wIdx to wIdx + 1
+            set tIdx to 0
+            repeat with t in tabs of w
+                set tIdx to tIdx + 1
+                set out to out & wIdx & tab & tIdx & tab & (URL of t) & linefeed
+            end repeat
+        end repeat
+        return out
+    end tell
+    '''
+    output = _osascript(script)
+    if not output:
+        return []
+    tabs = []
+    for line in output.splitlines():
+        parts = line.split('\t')
+        if len(parts) != 3:
+            continue
+        try:
+            tabs.append((int(parts[0]), int(parts[1]), parts[2]))
+        except ValueError:
+            continue
+    return tabs
+
+
+def _find_matching_tab(app_name, target_url):
+    """(window_index, tab_index) of the first open tab of app_name whose URL
+    matches target_url once tracking parameters are stripped from both and a
+    trailing slash is ignored, or None if no tab matches."""
+    target = clean_url(target_url).rstrip('/')
+    for win_idx, tab_idx, tab_url in _list_tabs(app_name):
+        if clean_url(tab_url).rstrip('/') == target:
+            return win_idx, tab_idx
+    return None
+
+
+def _capture_tab_dom(app_name, window_index, tab_index, timeout=20):
+    """The live DOM of one already-identified open tab, via each browser's
+    own JS-execution verb (they differ). None if capture fails - almost
+    always because the one-time Apple Events permission was never granted."""
+    if app_name == "Safari":
+        script = (
+            f'tell application "Safari" to do JavaScript "{_JS_OUTER_HTML}" '
+            f'in tab {tab_index} of window {window_index}'
+        )
+    else:  # Google Chrome
+        script = (
+            f'tell application "Google Chrome" to execute tab {tab_index} '
+            f'of window {window_index} javascript "{_JS_OUTER_HTML}"'
+        )
+    return _osascript(script, timeout=timeout)
+
+
+def browser_tab_dom(url):
+    """The rendered DOM of `url` and the browser it came from, if the page
+    happens to be open in a Safari or Chrome tab right now - (None, None)
+    otherwise (neither browser running, no matching tab, or the Apple Events
+    JS permission was never granted in the browser that does have it open).
+
+    Tried in place of a second HTTP fetch, never as a replacement for one:
+    this never launches a browser that isn't already running, and never
+    fetches or navigates a tab - only reads whatever page is already there.
+    """
+    for app_name in _BROWSER_APPS:
+        match = _find_matching_tab(app_name, url)
+        if not match:
+            continue
+        html = _capture_tab_dom(app_name, *match)
+        if html:
+            return html, app_name
+    return None, None
+
+
 def resolve_webloc(path):
     """Parse a .webloc plist and return its bookmarked URL, or None."""
     with open(path, 'rb') as f:
@@ -365,6 +489,20 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
     if not response.ok:
         if not is_bot_challenge(response):
             return f"Error: Could not fetch {url}: HTTP {response.status_code}"
+
+        # A browser already holding the session and a genuine fingerprint
+        # beats a DOI-only CrossRef record when the page is still open in a
+        # tab; falls through untouched below when it isn't.
+        html, browser_app = browser_tab_dom(url)
+        if html:
+            soup = BeautifulSoup(html, 'html.parser')
+            return SourceContent(
+                text=_page_text(soup),
+                metadata=_page_metadata(soup),
+                label=f"webpage (via {browser_app} tab)",
+                url=clean_url(url),
+            )
+
         fallback = crossref_fallback(url, crossref_email)
         if fallback:
             return fallback

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -247,44 +247,91 @@ def crossref_fallback(url, crossref_email=None):
 # plain HTTP client can satisfy. A browser the operator already has open
 # holds the session cookie and a genuine fingerprint, so when the bookmarked
 # URL happens to still be open in a tab, the DOM is taken from there instead
-# of fetching the page a second time. Requires a one-time setting in each
-# browser (Safari: Develop > Allow JavaScript from Apple Events; Chrome:
-# View > Developer > Allow JavaScript from Apple Events) that cannot be
-# detected in advance, so a missing permission is indistinguishable here from
-# a missing tab - both simply fall through to the existing failure path.
+# of fetching the page a second time.
+#
+# Every distinguishable way this can come up empty is reported separately.
+# The first version collapsed them all into None on the theory that the
+# caller only needed to know whether it had a DOM; that cost three rounds of
+# diagnosis on a single failure, because "Apple Events refused", "browser not
+# running" and "no tab matches" are the same symptom with entirely different
+# remedies. Nothing here launches a browser that isn't already running, and
+# nothing navigates a tab - it only reads what is already loaded.
 
 _BROWSER_APPS = ("Safari", "Google Chrome")
 _JS_OUTER_HTML = "document.documentElement.outerHTML"
 
+# osascript outcomes.
+OSA_OK = 'ok'
+OSA_REFUSED = 'refused'      # the Apple Events grant is missing or denied
+OSA_ERROR = 'error'          # anything else: no such tab, osascript absent, timeout
+
+# macOS reports a denied Apple Events grant as error -1743; the accompanying
+# wording varies by OS version and locale, so the numeric code is what this
+# matches on, with the English phrasings as a secondary net. Safari's separate
+# "Allow JavaScript from Apple Events" switch reports -1743 as well when off.
+_REFUSED_MARKERS = ('-1743', 'not authorized', 'not authorised', 'not allowed',
+                    'not permitted')
+
+# How many non-matching tab URLs to name before summarising the rest. Tabs on
+# the target's own host are always named in full regardless of this cap: they
+# are the ones worth eyeballing when a match was expected and didn't happen.
+_TAB_LOG_LIMIT = 12
+
 
 def _osascript(script, timeout=15):
-    """Run an AppleScript snippet, returning its stdout (stripped), or None
-    on any failure: osascript missing, the script errored (no permission, no
-    such window/tab), or it ran past timeout."""
+    """(status, text) - status is one of OSA_*; text is the script's stdout
+    when it ran, and osascript's stderr (or the exception) when it didn't."""
     try:
         result = subprocess.run(
             ['osascript', '-e', script],
             capture_output=True, text=True, timeout=timeout,
         )
-    except (subprocess.SubprocessError, OSError):
-        return None
-    if result.returncode != 0:
-        return None
-    return result.stdout.strip()
+    except subprocess.TimeoutExpired:
+        return OSA_ERROR, f"osascript timed out after {timeout}s"
+    except (subprocess.SubprocessError, OSError) as e:
+        return OSA_ERROR, str(e)
+    if result.returncode == 0:
+        return OSA_OK, result.stdout.strip()
+    stderr = (result.stderr or '').strip()
+    lowered = stderr.lower()
+    if any(marker in lowered for marker in _REFUSED_MARKERS):
+        return OSA_REFUSED, stderr
+    return OSA_ERROR, stderr or f"osascript exited {result.returncode}"
+
+
+# What one browser had to say about the target URL.
+BROWSER_MATCH = 'match'
+BROWSER_NOT_RUNNING = 'not running'
+BROWSER_NO_WINDOWS = 'running, no windows open'
+BROWSER_NO_MATCH = 'no matching tab'
+BROWSER_REFUSED = 'Apple Events refused'
+BROWSER_CAPTURE_REFUSED = 'tab matched, JavaScript from Apple Events refused'
+BROWSER_ERROR = 'error'
 
 
 def _browser_is_running(app_name):
-    """True if app_name is already running - checked so a closed browser is
-    never launched just to look for a tab that, by definition, isn't open."""
-    return _osascript(f'application "{app_name}" is running') == 'true'
+    """(is_running, status, detail). Checked before anything else so a closed
+    browser is never launched just to look for a tab that, by definition,
+    isn't open - and so a refused Apple Events grant is named as such rather
+    than silently read as "not running"."""
+    status, text = _osascript(f'application "{app_name}" is running')
+    if status == OSA_OK:
+        return text == 'true', OSA_OK, text
+    return False, status, text
 
 
 def _list_tabs(app_name):
-    """(window_index, tab_index, url) for every open tab of app_name, both
-    indices 1-based as AppleScript addresses them. Empty if the app isn't
-    running or has no windows."""
-    if not _browser_is_running(app_name):
-        return []
+    """(tabs, status, detail) - tabs is [(window_index, tab_index, url)] for
+    every open tab of app_name, both indices 1-based as AppleScript addresses
+    them."""
+    running, status, detail = _browser_is_running(app_name)
+    if status == OSA_REFUSED:
+        return [], BROWSER_REFUSED, detail
+    if status == OSA_ERROR:
+        return [], BROWSER_ERROR, detail
+    if not running:
+        return [], BROWSER_NOT_RUNNING, ''
+
     script = f'''
     tell application "{app_name}"
         if (count of windows) is 0 then return ""
@@ -301,9 +348,14 @@ def _list_tabs(app_name):
         return out
     end tell
     '''
-    output = _osascript(script)
+    status, output = _osascript(script)
+    if status == OSA_REFUSED:
+        return [], BROWSER_REFUSED, output
+    if status == OSA_ERROR:
+        return [], BROWSER_ERROR, output
     if not output:
-        return []
+        return [], BROWSER_NO_WINDOWS, ''
+
     tabs = []
     for line in output.splitlines():
         parts = line.split('\t')
@@ -313,24 +365,50 @@ def _list_tabs(app_name):
             tabs.append((int(parts[0]), int(parts[1]), parts[2]))
         except ValueError:
             continue
-    return tabs
+    return tabs, OSA_OK, ''
 
 
-def _find_matching_tab(app_name, target_url):
-    """(window_index, tab_index) of the first open tab of app_name whose URL
-    matches target_url once tracking parameters are stripped from both and a
-    trailing slash is ignored, or None if no tab matches."""
-    target = clean_url(target_url).rstrip('/')
-    for win_idx, tab_idx, tab_url in _list_tabs(app_name):
-        if clean_url(tab_url).rstrip('/') == target:
-            return win_idx, tab_idx
-    return None
+def _describe_tabs(tabs, target_url):
+    """The cleaned URLs of the tabs that did not match, as a list of log
+    lines - without this there is no way to tell a matching bug from an
+    absent tab.
+
+    Returned as separate lines, never one string with newlines in it: the
+    caller's log callback prefixes each message it is given, so an embedded
+    newline produces a ragged block in the progress window.
+
+    Tabs sharing the target's host are named in full however many there are;
+    everything else is capped, since a browser session can carry hundreds of
+    tabs that have no bearing on the question.
+    """
+    if not tabs:
+        return ["no tabs open"]
+    target_host = urlsplit(clean_url(target_url)).netloc.lower()
+    same_host, other = [], []
+    for _, _, tab_url in tabs:
+        cleaned = clean_url(tab_url).rstrip('/')
+        (same_host if urlsplit(cleaned).netloc.lower() == target_host else other).append(cleaned)
+
+    lines = [f"{len(tabs)} tab(s) open; none matched"]
+    if same_host:
+        lines.append(f"on {target_host} ({len(same_host)}):")
+        lines.extend(f"  {u}" for u in same_host)
+    else:
+        lines.append(f"none on {target_host}")
+    shown = other[:_TAB_LOG_LIMIT]
+    if shown:
+        lines.append(f"elsewhere ({len(other)}):")
+        lines.extend(f"  {u}" for u in shown)
+        if len(other) > len(shown):
+            lines.append(f"  ... and {len(other) - len(shown)} more")
+    return lines
 
 
 def _capture_tab_dom(app_name, window_index, tab_index, timeout=20):
-    """The live DOM of one already-identified open tab, via each browser's
-    own JS-execution verb (they differ). None if capture fails - almost
-    always because the one-time Apple Events permission was never granted."""
+    """(html, status, detail) for one already-identified open tab, via each
+    browser's own JS-execution verb (they differ). A refusal here is the
+    browser's separate "Allow JavaScript from Apple Events" switch, distinct
+    from the Apple Events grant that listing tabs already cleared."""
     if app_name == "Safari":
         script = (
             f'tell application "Safari" to do JavaScript "{_JS_OUTER_HTML}" '
@@ -341,27 +419,68 @@ def _capture_tab_dom(app_name, window_index, tab_index, timeout=20):
             f'tell application "Google Chrome" to execute tab {tab_index} '
             f'of window {window_index} javascript "{_JS_OUTER_HTML}"'
         )
-    return _osascript(script, timeout=timeout)
+    status, text = _osascript(script, timeout=timeout)
+    if status == OSA_REFUSED:
+        return None, BROWSER_CAPTURE_REFUSED, text
+    if status == OSA_ERROR:
+        return None, BROWSER_ERROR, text
+    if not text:
+        return None, BROWSER_ERROR, "the tab returned an empty document"
+    return text, BROWSER_MATCH, ''
 
 
-def browser_tab_dom(url):
-    """The rendered DOM of `url` and the browser it came from, if the page
-    happens to be open in a Safari or Chrome tab right now - (None, None)
-    otherwise (neither browser running, no matching tab, or the Apple Events
-    JS permission was never granted in the browser that does have it open).
+def browser_tab_dom(url, log=None):
+    """(html, app_name, summary) - the rendered DOM of `url` and the browser
+    it came from, if the page happens to be open in a Safari or Chrome tab
+    right now; (None, None, summary) otherwise.
 
-    Tried in place of a second HTTP fetch, never as a replacement for one:
-    this never launches a browser that isn't already running, and never
-    fetches or navigates a tab - only reads whatever page is already there.
+    `summary` says what each browser reported, so the caller can tell a
+    refused Apple Events grant from a closed browser from a tab that simply
+    isn't there. `log`, if given, receives the same information as it is
+    discovered, including the cleaned URLs of the tabs that were examined and
+    did not match.
     """
+    log = log or (lambda msg: None)
+    target = clean_url(url).rstrip('/')
+    log(f"Browser capture: looking for {target}")
+
+    outcomes = []
     for app_name in _BROWSER_APPS:
-        match = _find_matching_tab(app_name, url)
-        if not match:
+        tabs, status, detail = _list_tabs(app_name)
+
+        if status in (BROWSER_REFUSED, BROWSER_ERROR):
+            outcomes.append(f"{app_name}: {status}" + (f" ({detail})" if detail else ""))
+            log(f"  {app_name}: {status}" + (f" - {detail}" if detail else ""))
             continue
-        html = _capture_tab_dom(app_name, *match)
+        if status in (BROWSER_NOT_RUNNING, BROWSER_NO_WINDOWS):
+            outcomes.append(f"{app_name}: {status}")
+            log(f"  {app_name}: {status}")
+            continue
+
+        match = None
+        for win_idx, tab_idx, tab_url in tabs:
+            if clean_url(tab_url).rstrip('/') == target:
+                match = (win_idx, tab_idx)
+                break
+
+        if not match:
+            outcomes.append(f"{app_name}: {BROWSER_NO_MATCH} ({len(tabs)} tab(s) examined)")
+            described = _describe_tabs(tabs, url)
+            log(f"  {app_name}: {described[0]}")
+            for line in described[1:]:
+                log(f"    {line}")
+            continue
+
+        html, cap_status, cap_detail = _capture_tab_dom(app_name, *match)
         if html:
-            return html, app_name
-    return None, None
+            log(f"  {app_name}: matched window {match[0]} tab {match[1]}; "
+                f"captured {len(html)} characters")
+            return html, app_name, f"{app_name}: {BROWSER_MATCH}"
+        outcomes.append(f"{app_name}: {cap_status}" + (f" ({cap_detail})" if cap_detail else ""))
+        log(f"  {app_name}: matched window {match[0]} tab {match[1]}, but {cap_status}"
+            + (f" - {cap_detail}" if cap_detail else ""))
+
+    return None, None, '; '.join(outcomes)
 
 
 def resolve_webloc(path):
@@ -603,19 +722,13 @@ def _content_plausible(content, candidate_urls, soup=None):
     return True, None, False, None
 
 
-def _log_source(chosen, url, amber_reason=None):
-    """State which path produced the text for `url` - printed unconditionally
-    (matching extract_pages.py's OCR-retry warnings) so this is visible in
-    normal output with nothing to instrument."""
-    suffix = f" [amber: {amber_reason}]" if amber_reason else ""
-    print(f"   Source: {chosen} for {url}{suffix}", file=sys.stderr)
+def _stderr_log(msg):
+    """Default sink when no caller-supplied log is given - direct module use,
+    tests, and the CLI without the progress window."""
+    print(f"   {msg}", file=sys.stderr)
 
 
-def _log_rejected(path_label, reason, next_step):
-    print(f"   ⚠️  {path_label} rejected ({reason}); trying {next_step}", file=sys.stderr)
-
-
-def extract_webloc(webloc_path, timeout=20, crossref_email=None):
+def extract_webloc(webloc_path, timeout=20, crossref_email=None, log=None):
     """
     Extract a .webloc bookmark's target page as a SourceContent.
 
@@ -637,9 +750,24 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
     record for a URL that's simply dead (a plain 404) - the original
     rationale for that gate, unchanged here.
 
+    `log`, if given, is called with short human-readable strings naming which
+    path produced the text and why each rejected path was rejected - the same
+    shape enrich.verify_recollection(log=...) uses, so biblio_agent can route
+    it through _log() and it reaches the progress window as well as stderr.
+    Defaults to stderr alone, which is invisible in the windowed run.
+
     Returns:
         SourceContent on success, or a string starting with "Error:" on failure.
     """
+    log = log or _stderr_log
+
+    def log_source(chosen, amber_reason=None):
+        suffix = f" [amber: {amber_reason}]" if amber_reason else ""
+        log(f"Source: {chosen} for {url}{suffix}")
+
+    def log_rejected(path_label, reason, next_step):
+        log(f"⚠️  {path_label} rejected ({reason}); trying {next_step}")
+
     webloc_path = Path(webloc_path)
 
     if not webloc_path.exists():
@@ -666,27 +794,29 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
         ok, reason, amber, amber_reason = _content_plausible(content, {url, response.url}, soup)
         if ok:
             content.amber, content.amber_reason = amber, amber_reason
-            _log_source("fetch", url, amber_reason)
+            log_source("fetch", amber_reason)
             return content
         rejected.append(("fetch", reason))
-        _log_rejected("fetch", reason, "a browser tab")
+        log_rejected("fetch", reason, "a browser tab")
 
     # Tried on ANY failure - non-2xx status or a 200 that didn't pass the
     # plausibility check - not only a classified bot challenge: a browser
     # already holding the session and a genuine TLS fingerprint beats
     # whatever the plain HTTP client got back, and DataDome/Kasada/consent-
     # wall interstitials never trip is_bot_challenge at all.
-    html, browser_app = browser_tab_dom(url)
+    html, browser_app, browser_summary = browser_tab_dom(url, log=log)
     if html:
         label = f"browser tab ({browser_app})"
         content, soup = _content_from_html(html, url, f"webpage (via {browser_app} tab)")
         ok, reason, amber, amber_reason = _content_plausible(content, {url}, soup)
         if ok:
             content.amber, content.amber_reason = amber, amber_reason
-            _log_source(label, url, amber_reason)
+            log_source(label, amber_reason)
             return content
+        # Distinct from "no tab was found": a tab WAS captured and its
+        # content examined, and it is the content that was refused.
         rejected.append((label, reason))
-        _log_rejected(label, reason, "CrossRef" if challenge else "reporting failure")
+        log_rejected(label, reason, "CrossRef" if challenge else "reporting failure")
 
     if challenge:
         fallback = crossref_fallback(url, crossref_email)
@@ -694,16 +824,25 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
             ok, reason, amber, amber_reason = _content_plausible(fallback, {url}, soup=None)
             if ok:
                 fallback.amber, fallback.amber_reason = amber, amber_reason
-                _log_source("CrossRef", url, amber_reason)
+                log_source("CrossRef", amber_reason)
                 return fallback
             rejected.append(("CrossRef", reason))
-            _log_rejected("CrossRef", reason, "reporting failure")
+            log_rejected("CrossRef", reason, "reporting failure")
 
-    _log_source("failure", url)
+    log_source("failure")
+
+    # The browser summary goes into the error text whether or not a tab was
+    # found, and says which of the distinguishable outcomes occurred. Without
+    # it the returned string cannot tell "no browser was consulted" from "the
+    # grant was refused" from "no tab matched" - the conflation that made a
+    # single failure take three rounds to diagnose.
+    browser_note = f"; browser tab: {browser_summary}" if browser_summary else ""
+
     if rejected:
         detail = '; '.join(f"{path}: {reason}" for path, reason in rejected)
-        return f"Error: {url} yielded no plausible source ({detail})"
+        return f"Error: {url} yielded no plausible source ({detail}){browser_note}"
     if challenge:
         return (f"Error: {url} is behind a bot challenge (HTTP "
-                f"{response.status_code}) and its URL carries no DOI to fall back on")
-    return f"Error: Could not fetch {url}: HTTP {response.status_code}"
+                f"{response.status_code}) and its URL carries no DOI to fall back on"
+                f"{browser_note}")
+    return f"Error: Could not fetch {url}: HTTP {response.status_code}{browser_note}"

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -496,9 +496,16 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
         html, browser_app = browser_tab_dom(url)
         if html:
             soup = BeautifulSoup(html, 'html.parser')
+            # Metadata before text: _page_text() decomposes <script> tags,
+            # which destroys the JSON-LD block _page_metadata() reads from -
+            # keyword arguments evaluate left to right regardless of the
+            # order they're written in, so text=/metadata=/... below would
+            # silently lose Author/PublicationDate from JSON-LD-only pages.
+            metadata = _page_metadata(soup)
+            text = _page_text(soup)
             return SourceContent(
-                text=_page_text(soup),
-                metadata=_page_metadata(soup),
+                text=text,
+                metadata=metadata,
                 label=f"webpage (via {browser_app} tab)",
                 url=clean_url(url),
             )
@@ -511,9 +518,13 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
 
     soup = BeautifulSoup(response.text, 'html.parser')
 
+    # Metadata before text - see the identical comment in the browser-DOM
+    # branch above.
+    metadata = _page_metadata(soup)
+    text = _page_text(soup)
     return SourceContent(
-        text=_page_text(soup),
-        metadata=_page_metadata(soup),
+        text=text,
+        metadata=metadata,
         label="webpage",
         # Final URL after any redirects (e.g. DOI resolvers), minus tracking.
         url=clean_url(response.url),

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -478,8 +478,18 @@ def _content_from_html(html, source_url, label):
 # gates and login walls commonly answer 200 with an interstitial instead -
 # there is no error to classify, so the only thing that tells it apart from
 # the article is what actually came back. Applied identically to every path
-# that can produce a SourceContent (fetch, browser tab, CrossRef), so none
-# of the three can hand the model a confident wrong entry.
+# that can produce a SourceContent (fetch, browser tab, CrossRef).
+#
+# Only one thing here is a hard failure: the content doesn't correspond to
+# the URL requested - that's the wrong document, not a sparse one, and no
+# amount of metadata completeness excuses it. Everything else this checks
+# (missing identifying fields, a thin body) is genuine-but-sparse rather
+# than wrong, and is flagged amber (SourceContent.amber, folded into
+# biblio_agent.py's existing "needs_color" mechanism) instead of discarded -
+# this library carries plenty of real @Online sources (a personal page, a
+# manufacturer's spec sheet) with a Title and nothing else, for which
+# Urldate is the normal, correct dating evidence per CLAUDE.md, not a
+# consolation prize.
 
 _IDENTIFYING_FIELDS = ('Author', 'Doi', 'PublicationDate')
 
@@ -554,31 +564,51 @@ def _url_correspondence(candidate_urls, soup, metadata):
 
 
 def _content_plausible(content, candidate_urls, soup=None):
-    """(is_plausible, reason) - whether `content` genuinely describes the
-    bookmarked work, applied the same way regardless of which path produced
-    it. `candidate_urls` is every URL the content may legitimately declare
-    itself as (see _url_correspondence); `soup` is the parsed page for the
-    fetch/browser-tab paths, or None for CrossRef, which has no page to read
-    a canonical link or og:url from.
+    """(ok, reason, amber, amber_reason).
+
+    `ok=False` only for a URL-correspondence mismatch - the one case this
+    treats as the wrong document rather than a sparse one. Every other
+    outcome is `ok=True`: `amber=True` marks content worth a human glance
+    (no Title, or identifying fields thin enough that only Urldate is left
+    to date it, or - for HTML-derived content only - a body under
+    MIN_BODY_WORDS) without discarding it. `candidate_urls` is every URL the
+    content may legitimately declare itself as (see _url_correspondence);
+    `soup` is the parsed page for the fetch/browser-tab paths, or None for
+    CrossRef, which has no page to read a canonical link or og:url from (and
+    whose own metadata block is exempt from the length check - see
+    MIN_BODY_WORDS).
     """
     metadata = content.metadata
-    if not metadata.get('Title'):
-        return False, "no Title in the extracted metadata"
-    if not any(metadata.get(f) for f in _IDENTIFYING_FIELDS):
-        return False, "Title but no Author/Doi/PublicationDate - looks like an interstitial"
+
     ok, reason = _url_correspondence(candidate_urls, soup, metadata)
     if not ok:
-        return False, reason
+        return False, reason, False, None
+
+    amber_bits = []
+    if not metadata.get('Title'):
+        amber_bits.append("no Title in the extracted metadata")
+    if not any(metadata.get(f) for f in _IDENTIFYING_FIELDS):
+        # Not a hard fail: a Title with no Author/Doi/PublicationDate still
+        # has Urldate to date it by (this project's own convention for an
+        # entry with no stated Date - CLAUDE.md), which is a normal, valid
+        # @Online source, not a defective one. Flagged amber rather than
+        # passed clean, though, since it's the sparsest shape that's still
+        # usable at all.
+        amber_bits.append("no Author/Doi/PublicationDate - only Urldate available to date it")
     if soup is not None and len(split_into_words(content.text)) < MIN_BODY_WORDS:
-        return False, f"body text under {MIN_BODY_WORDS} words - looks like a page still loading"
-    return True, None
+        amber_bits.append(f"body text under {MIN_BODY_WORDS} words")
+
+    if amber_bits:
+        return True, None, True, '; '.join(amber_bits)
+    return True, None, False, None
 
 
-def _log_source(chosen, url):
+def _log_source(chosen, url, amber_reason=None):
     """State which path produced the text for `url` - printed unconditionally
     (matching extract_pages.py's OCR-retry warnings) so this is visible in
     normal output with nothing to instrument."""
-    print(f"   Source: {chosen} for {url}", file=sys.stderr)
+    suffix = f" [amber: {amber_reason}]" if amber_reason else ""
+    print(f"   Source: {chosen} for {url}{suffix}", file=sys.stderr)
 
 
 def _log_rejected(path_label, reason, next_step):
@@ -592,10 +622,11 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
     Three paths are tried in order - an ordinary fetch, a browser tab already
     open on the bookmarked URL, and the CrossRef record for a DOI in the
     URL's own path - and every one of them is checked for plausibility
-    before being trusted (see _content_plausible): the metadata must
-    identify a work, and the content must correspond to the requested URL.
-    A path that fails the check is treated exactly like a path that produced
-    nothing at all, and the next one is tried.
+    before being trusted (see _content_plausible). Only a URL-correspondence
+    mismatch is treated as a failed path (nothing produced, next path
+    tried); missing identifying metadata or a thin body still return the
+    content, marked amber (SourceContent.amber/amber_reason) for a human to
+    glance at rather than trust blind.
 
     The browser tab is tried on any failure of the fetch (a non-2xx status,
     or a 200 that failed the plausibility check) - a tab rendering the page
@@ -632,9 +663,10 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
 
     if response.ok:
         content, soup = _content_from_html(response.text, response.url, "webpage")
-        ok, reason = _content_plausible(content, {url, response.url}, soup)
+        ok, reason, amber, amber_reason = _content_plausible(content, {url, response.url}, soup)
         if ok:
-            _log_source("fetch", url)
+            content.amber, content.amber_reason = amber, amber_reason
+            _log_source("fetch", url, amber_reason)
             return content
         rejected.append(("fetch", reason))
         _log_rejected("fetch", reason, "a browser tab")
@@ -648,9 +680,10 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
     if html:
         label = f"browser tab ({browser_app})"
         content, soup = _content_from_html(html, url, f"webpage (via {browser_app} tab)")
-        ok, reason = _content_plausible(content, {url}, soup)
+        ok, reason, amber, amber_reason = _content_plausible(content, {url}, soup)
         if ok:
-            _log_source(label, url)
+            content.amber, content.amber_reason = amber, amber_reason
+            _log_source(label, url, amber_reason)
             return content
         rejected.append((label, reason))
         _log_rejected(label, reason, "CrossRef" if challenge else "reporting failure")
@@ -658,9 +691,10 @@ def extract_webloc(webloc_path, timeout=20, crossref_email=None):
     if challenge:
         fallback = crossref_fallback(url, crossref_email)
         if fallback:
-            ok, reason = _content_plausible(fallback, {url}, soup=None)
+            ok, reason, amber, amber_reason = _content_plausible(fallback, {url}, soup=None)
             if ok:
-                _log_source("CrossRef", url)
+                fallback.amber, fallback.amber_reason = amber, amber_reason
+                _log_source("CrossRef", url, amber_reason)
                 return fallback
             rejected.append(("CrossRef", reason))
             _log_rejected("CrossRef", reason, "reporting failure")

--- a/src/web_source.py
+++ b/src/web_source.py
@@ -700,6 +700,15 @@ _STRUCTURAL_PATH_WORDS = {
 # articles from the same year look like the same work.
 _ARTICLE_ID_RE = re.compile(r'^\d{5,}$')
 
+# An opaque record token: Cambridge Core's 32-character hex, arXiv's
+# 2401.01234, a handle's mdp.39015012345678, a DOI suffix. Letters and digits
+# and dots only - no hyphens, which is what keeps title slugs out of this
+# class - and at least one digit, so an ordinary word never qualifies.
+_OPAQUE_ID_RE = re.compile(r'^(?=[^\d]*\d)[A-Za-z0-9.]{8,}$')
+
+# A file extension naming how a work is served, not which work it is.
+_SERVING_EXTENSION_RE = re.compile(r'\.(pdf|html?|xml|epub|txt|full)$', re.I)
+
 
 def _is_structural_segment(segment):
     parts = [p for p in segment.lower().split('-') if p]
@@ -707,25 +716,37 @@ def _is_structural_segment(segment):
 
 
 def _identifying_segments(path):
-    """The path segments that identify *which work* a URL names.
+    """(ids, slugs) - the path segments that identify *which work* a URL names.
 
-    Two kinds qualify: a long numeric article id, and a title slug. A slug
-    must carry at least two hyphens and sixteen characters and must not be
-    built purely of structural words - `music-theory` or `article-abstract`
-    would otherwise match two entirely different articles on the same host,
-    which is the one error this check exists to prevent.
+    Kept apart because they carry different authority. An id names one
+    record; a slug is usually a title, but on some platforms it is the
+    *container*: Cambridge Core writes
+    /core/journals/twentieth-century-music/article/abs/<title>/<hex id>,
+    where the journal name is a long hyphenated segment shared by every
+    article in the journal. Treating that as identifying matched two
+    unrelated articles - the exact publisher-shaped assumption this
+    separation exists to remove. See _url_matches for how a conflicting id
+    now overrules a shared slug.
+
+    A slug must carry at least two hyphens and sixteen characters and must
+    not be built purely of structural words, so `music-theory` or
+    `article-abstract` cannot stand in for a title.
     """
-    found = set()
+    ids, slugs = set(), set()
     for segment in path.split('/'):
         segment = segment.strip()
         if not segment:
             continue
-        if _ARTICLE_ID_RE.match(segment):
-            found.add(segment)
-        elif (len(segment) >= 16 and segment.count('-') >= 2
-                and not _is_structural_segment(segment)):
-            found.add(segment.lower())
-    return found
+        if _ARTICLE_ID_RE.match(segment) or _OPAQUE_ID_RE.match(segment):
+            ids.add(segment.lower())
+            continue
+        # A serving extension is a form, not an identity: the same work is
+        # <slug> as a landing page and <slug>.pdf as a download.
+        bare = _SERVING_EXTENSION_RE.sub('', segment)
+        if (len(bare) >= 16 and bare.count('-') >= 2
+                and not _is_structural_segment(bare)):
+            slugs.add(bare.lower())
+    return ids, slugs
 
 
 def _url_matches(a, b):
@@ -753,14 +774,45 @@ def _url_matches(a, b):
     if parts_a.netloc.lower() != parts_b.netloc.lower():
         return False
 
-    # A DOI on both sides settles it outright, either way.
-    dois_a = {d.lower() for d in doi_candidates(clean_a)}
-    dois_b = {d.lower() for d in doi_candidates(clean_b)}
-    if dois_a and dois_b:
-        return bool(dois_a & dois_b)
+    # A DOI on both sides settles it outright, either way - but only the
+    # LONGEST candidate may be compared, never the truncation ladder
+    # doi_candidates() offers for CrossRef lookups. Intersecting the ladders
+    # matched two different Grove Music entries, whose paths share the
+    # dictionary's own DOI stem (10.1093/gmo) and differ only past it.
+    #
+    # One DOI extending the other by a further path segment is still the
+    # same work: Silverchair appends its article id, so
+    # 10.1093/jaac/kpag034/8725072 and 10.1093/jaac/kpag034 are one record.
+    doi_a = (doi_candidates(clean_a) or [''])[0].lower().rstrip('/')
+    doi_b = (doi_candidates(clean_b) or [''])[0].lower().rstrip('/')
+    if doi_a and doi_b:
+        return (doi_a == doi_b
+                or doi_a.startswith(doi_b + '/')
+                or doi_b.startswith(doi_a + '/'))
 
-    ids_a, ids_b = _identifying_segments(parts_a.path), _identifying_segments(parts_b.path)
-    return bool(ids_a and ids_b and (ids_a & ids_b))
+    ids_a, slugs_a = _identifying_segments(parts_a.path)
+    ids_b, slugs_b = _identifying_segments(parts_b.path)
+
+    # Disagreement within a class that BOTH sides populate settles it: these
+    # are different records, however much of the rest of the path agrees.
+    # The veto has to run over both classes, because which class carries the
+    # discriminating token is a per-publisher accident:
+    #
+    #   Cambridge Core  /journals/<journal-slug>/article/abs/<title>/<hex id>
+    #     - the journal slug is shared by every article, so the ID vetoes;
+    #   Grove Music     /view/10.1093/gmo/<dictionary id>/<entry slug>
+    #     - the dictionary id is shared by every entry, so the SLUG vetoes.
+    #
+    # Checking only ids matched two unrelated Grove entries; checking only
+    # slugs matched two unrelated Cambridge articles. Both were real.
+    if ids_a and ids_b and not (ids_a & ids_b):
+        return False
+    if slugs_a and slugs_b and not (slugs_a & slugs_b):
+        return False
+
+    # A class only one side populates is not a conflict: /article/<id>/<slug>
+    # and a bare /<slug> form can be the same work.
+    return bool((ids_a & ids_b) or (slugs_a & slugs_b))
 
 
 def _url_correspondence(candidate_urls, soup, metadata):


### PR DESCRIPTION
Closes #8

## Summary

`extract_webloc()` tries three paths in order for a `.webloc` bookmark - an
ordinary fetch, a browser tab already open on the bookmarked URL, and the
CrossRef record for a DOI in the URL's own path - and checks every one of
them for content plausibility before trusting it, rather than only
classifying the HTTP failure shape the way the first version of this PR did.

1. **Browser tab, tried on any fetch failure** (any non-2xx status, or a 200
   whose content failed the plausibility check below) - not gated on a
   classified bot challenge. A tab rendering the page is proof of life no
   HTTP response can provide, whatever its status code, and some gatekeepers
   (DataDome, Kasada, consent/login walls) answer 200 with an interstitial,
   which a status-code classifier can never catch.
2. **Content plausibility, applied to every path** (fetch, browser tab,
   CrossRef): does the metadata identify a work, and does the content
   correspond to the requested URL (its own canonical link, `og:url`, or an
   embedded DOI). Only a URL-correspondence mismatch - the wrong document -
   is a hard failure; a source that's merely thin (no Author/Doi/
   PublicationDate beyond an access-date `Urldate`, or a short body) still
   produces an entry, marked amber (`SourceContent.amber`/`amber_reason`,
   folded into the existing BibDesk `needs_color` mechanism) rather than
   discarded. This library carries plenty of real `@online` sources - a
   personal page, a manufacturer's spec sheet - with a title and nothing
   else, for which `Urldate` is the ordinary dating evidence, not a defect.
3. **CrossRef, still gated on a classified bot challenge** (`is_bot_challenge`),
   unchanged from the original design: unlike the browser path it has no page
   to check against, only a DOI mined from the URL, so trying it on every
   failure risks filing a record for a URL that's simply dead.
4. Every path logs which one won (or why each was rejected) to stderr,
   unconditionally.

Two defects found and fixed along the way, unrelated to the above but
necessary for it to work correctly:

- `SourceContent(text=_page_text(soup), metadata=_page_metadata(soup), ...)`
  evaluated `text=` before `metadata=` (keyword arguments evaluate left to
  right regardless of write order), and `_page_text()` decomposes `<script>`
  tags - destroying the JSON-LD block `_page_metadata()` reads Author/
  PublicationDate from. **Scope:** this only affects a `.webloc` page this
  pipeline extracts going forward; it has no bearing on, and required no
  recovery pass against, any entry already in the library (all hand-made,
  none passed through this code).
- `save_entry()`'s `% Source: ...` marker-extraction regex placed its `\b`
  word-boundary assertion immediately after the literal `:` - impossible,
  since neither side of that position is a word character - so it never
  matched. Because that marker is always the first line and `re.match`
  anchors at position 0, every marker regex after it (including
  `NEEDS_COLOR_FLAG`) also failed to match against the unrelated leading
  text. **Scope:** `needs_color` was `False` unconditionally for every entry
  ever saved, PDF or `.webloc` - BibDesk's amber coloring has been inert
  since it was introduced, not merely blind to `.webloc` sources.

## Testing

No network, no browser, no API call anywhere in this session.

- `dev/test_web_source.py` (15 cases): every case #11 asked for plus
  regressions for the gate split, the redirect/DOI-correspondence fix, and
  the amber-vs-fail split - asserting on the outcome, the `.amber`/
  `.amber_reason` marking, and the logged source path together.
- `dev/test_biblio_agent_markers.py` (2 cases): the marker round trip through
  the real `save_entry()` (config.yaml as-is, `main_bib_file` redirected to a
  temp path, `autofile_bibdesk` off - the Anthropic client is constructed but
  never called) - confirms `NEEDS_COLOR_FLAG` is discarded while `% Source:`
  and `% AMBER:` persist in order, and that an entry with no `AMBER` marker
  is unaffected.
- `dev/test_setup.py` and `dev/eval/test_eval.py` both pass.

**Not verified**: a live Safari/Chrome tab with the Apple Events permission
(confirmed working on the author's machine, but not exercised by any
automated test here), a real Cloudflare/DataDome/consent-wall page in the
wild, and whether `MIN_BODY_WORDS = 100` (provisional, pending #16) is the
right floor for real `.webloc` sources after chrome-stripping.

## Decisions

- **Only correspondence mismatch is a hard failure.** Originally this PR also
  hard-failed on missing identifying metadata and a thin body; narrowed after
  review against this library's real corpus (40 of 65 `@online`/`@periodical`
  entries carry no `Date`, all legitimate, all predating this pipeline). The
  tradeoff: a genuine interstitial that happens to carry no correspondence-
  contradicting signal of its own now produces an amber entry rather than
  failing outright - accepted deliberately ("an amber entry I can finish by
  hand in thirty seconds beats a failure I have to redo from scratch"), not
  an oversight.
- **Browser tab tried before CrossRef, not after or instead of it** (carried
  over from the original design): a live tab is strictly richer than a
  DOI-only record whenever it's available.
- **Only Safari and Chrome**; no Firefox/Edge/Arc (carried over: neither
  exposes the same AppleScript JS-execution verbs).
- **A missing Apple Events permission and a missing tab are indistinguishable**
  from the caller's side (carried over): both just fall through.
- **`MIN_BODY_WORDS = 100`** is a provisional floor pending #16's own
  thin-yield threshold, borrowed from `extract_pages.py`'s existing
  OCR-retry threshold (same value) as the closest precedent in this codebase.
  Its stakes are lower than they look: a wrong value now costs an amber
  flag, not a lost entry.
