### PR TITLE
Document dev/eval/baselines/ in the Project Structure tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ ostracon-ai/
 │       ├── select_sample.py      # Builds sample/ and expected.bib from biblio.bib
 │       ├── populate_sample.py    # BibDesk attachment resolver select_sample.py imports
 │       ├── expected.bib          # Ground-truth entries; empty until populated
+│       ├── baselines/            # One dated report per full run; the comparison point
 │       └── sample/
 │           ├── manifest.json     # citekey/source/hash list; empty until populated
 │           └── selection.json    # Provenance of the last select_sample.py run

--- a/dev/test_setup.py
+++ b/dev/test_setup.py
@@ -212,6 +212,16 @@ def test_documentation():
     paths = [Path(f) for f in tracked
              if Path(f).name not in boilerplate and Path(f).suffix != ".png"]
 
+    # Directories whose contents are dated run artifacts rather than code:
+    # every full evaluation run adds a `<date>.md` here, and naming each one
+    # in the tree would mean a README edit per run and a failing check for
+    # whoever forgets. Documenting the directory documents its contents - but
+    # the directory itself must still be named, so the tree cannot stay silent
+    # about it either.
+    dated_dirs = {"dev/eval/baselines"}
+    paths = [p for p in paths
+             if str(p.parent) not in dated_dirs or not _names(readme, f"{p.parent.name}/")]
+
     # The tree names files by basename under a directory node, so match on the
     # basename and check the directory separately.
     missing = sorted({p.name for p in paths if not _names(readme, p.name)})


### PR DESCRIPTION
`dev/test_setup.py` fails its documentation-drift check on a clean `main`:

```
✗ files not in Project Structure: 2026-08-29.md
```

It is an optional failure, so the run still ends "Core requirements met" — but this is the pre-commit check CLAUDE.md's Autonomous sessions section requires before every commit, and it would fail again after every full evaluation run.

## What changed

- README.md's Project Structure tree gains a `baselines/` node under `dev/eval/`.
- `test_setup.py` gains a `dated_dirs` set (currently just `dev/eval/baselines`): a file sitting directly in one of those counts as documented **provided the tree names the directory**. Silence about the directory is still a failure.

## What the test establishes, and what it assumes

Verified in both directions, which matters because the passing direction alone would also pass against a checker that had simply stopped looking:

- With the README line present: `✓ all 37 tracked files listed`.
- With the README line removed and nothing else changed: `✗ files not in Project Structure: 2026-08-29.md` — the original failure, unchanged.

Not established: that a *second* baseline file would also pass. That follows from the code path (the filter is on `p.parent`, not on the filename) but no second file exists yet to run it against.

## Decisions

Alternative considered and rejected: naming `2026-08-29.md` in the tree literally. Smaller diff, no checker change — but it re-breaks on the next run and pushes the problem to whoever forgets, which is the state this issue is about.

Also considered: making any file documented by its parent directory, generally. Rejected as too broad — it would let a new file under `src/` pass unnamed, which is exactly what this check exists to catch.

## Verification environment

Run under `~/.micromamba/envs/biblio-ai` (Python 3.13.11), the maintainer's own environment. No API calls.

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjmVC9CiFbyxSjHeKfxZY4

---

## Merge order and conflicts

Six PRs touch overlapping documentation. Merging in this order resolves the
dependencies: **#22 → #26 → #28 → #27 → #25 → #29.**

Two files need hand-resolution whatever the order:

- **`dev/eval/sample/README.md`** — #26 and #28 both extend the same `note`
  bullet block, one adding `container_source`, the other `insufficient_source`.
  A certain conflict; both blocks are wanted.
- **`README.md`** — #27 rewrites the `test_biblio_agent_markers.py` paragraph;
  #28 inserts its `test_extract_pages.py` paragraph anchored on that paragraph's
  old first line.

One genuine dependency: **#28's `sample/README.md` says `select_sample.py`
preserves hand-added manifest keys across a regeneration. That code is only in
#26.** Until #26 lands, the sentence is false and a rerun of `select_sample.py`
would silently drop both `container_source` and `insufficient_source`.

---

# Measured: full 61-entry run of the merged state

The maintainer authorized one full run. It was spent on `integration-2026-08-29` —
all six PRs merged, in the order above, two documentation conflicts resolved by
hand — because that is the state `main` will actually have, and because one run of
the merge answers questions no single branch could. Full record:
[`dev/eval/baselines/2026-08-29-integration.md`](dev/eval/baselines/2026-08-29-integration.md).

**Entry type 50/61 → 51/61.** **Field verdicts: exact 249 → 240, different 117 →
117, missing 94 → 103, spurious 83 → 67** — sixteen fields the pipeline used to
invent it no longer invents, nine it used to get right it now omits, and nothing
moved into `different`.

**This PR was exercised by the run.** Adding
`dev/eval/baselines/2026-08-29-integration.md` is exactly the second-dated-file
case: before this change the drift check would have failed on it by name; after it,
`✓ all 39 tracked files listed`. The predicted behaviour, on a real new file rather
than a simulated one.

---

## Correction to the field figures above

`expected.bib` changed twice on 2026-08-29 — `4dff992` (Menke2004's author) and
`7155812` (Arndt2014's title, Cavell1969a's pages) — and the field table published
in `2026-08-29.md` predates both. Comparing this run against that table would have
been comparing two ground truths.

Re-scored the baseline run's own saved output against `expected.bib` as it now
stands, so both sides face one ground truth. **The delta is unchanged:
exact 249 → 240, different 117 → 117, missing 94 → 103, spurious 83 → 67.** The
totals coincide with the published ones by accident — `author` moves 33 → 34 and
`title` 37 → 36 under the corrected file, and they offset.

Two issues this session filed are now closed as **resolved by the maintainer's
correction**, not as mistaken: #24 (real, and fixed in `7155812` mid-session — I
later checked an already-fixed file and wrongly retracted it) and #20 (real, though
the value I proposed, `180-212`, was wrong; it is `180-201`).
