### PR TITLE
State the @Review title/shorttitle convention inline instead of citing an absent example

### DIFF
--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -460,10 +460,23 @@ excerpt's text won't (e.g. an embedded Author field):
    clause, is incomplete. Where one review covers several works, each keeps
    its own \\bibstring{by} clause in both fields.
 
-   Title holds the reviewed work's own title and author and nothing else.
-   Volume/series/translator/editor detail printed alongside it on the review's
-   first page ("Vol. III of ...", "translated and edited by ...") belongs to
-   the volume being reviewed, not to this entry's Title - leave it out.
+   Title holds the reviewed work's own title and author and nothing else. The
+   publishing apparatus printed alongside them on the review's first page -
+   volume or series position ("Vol. III of ..."), translator and editor
+   credits ("translated and edited by ..."), publisher, place, price - belongs
+   to the volume under review, not to this entry's Title. Leave it out.
+
+   That is a rule about which FACTS Title carries. It is not licence to
+   simplify how the title and author are written: inside Title and Shorttitle
+   alike, encode them exactly as the guidelines require of any other entry.
+   In particular, and these are the two that go wrong -
+   - a reviewed title, or the part of one, in a language other than the
+     review's own still takes its \\foreignlanguage{<language>}{...} wrapper,
+     inside \\mkbibemph; and
+   - a forename followed by an initial still takes the non-breaking tie:
+     \\bibstring{by} Lee~A. Rothfarb, never "Lee A. Rothfarb".
+   The Kivy example above is short only because that title is English and that
+   author has no initial; it is not a model for stripping either.
 
    Do not use a generic @Article for a review. Conversely, an article that
    merely discusses, cites or responds to other publications is NOT a review:

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -439,10 +439,36 @@ excerpt's text won't (e.g. an embedded Author field):
    @Unpublished (anything else unpublished, including a conference paper with
    no proceedings volume - see the guidelines for the required Note field).
    For a review of another work (rather than a standalone article), use
-   @Review and encode the reviewed work's title/author directly into Title
-   per the convention in the guidelines and demonstrated in
-   biblio-template.bib's Dunsby1997 entry - do not use a generic @Article for
-   a review.
+   @Review. The reviewed work is encoded directly into Title, and a
+   compressed form of it into Shorttitle, using exactly this construction:
+
+     Title = {\\bibstring{reviewof} \\mkbibemph{Authenticities: Philosophical
+       Reflections on Musical Performance}, \\bibstring{by} Peter Kivy},
+     Shorttitle = {\\bibstring{reviewof} \\mkbibemph{Authenticities},
+       \\bibstring{by} Kivy},
+
+   The name after \\bibstring{by} is the author of the work BEING REVIEWED. It
+   is never the reviewer, who is this entry's own Author and appears nowhere
+   in Title or Shorttitle - identify the two people separately.
+
+   Shorttitle compresses in two ways at once, and BOTH are required:
+   - the reviewed title is cut back to its first few words (at the colon,
+     where there is one), and
+   - the reviewed author is reduced to a bare surname, no forenames or
+     initials.
+   A Shorttitle that stops after the reviewed title, with no \\bibstring{by}
+   clause, is incomplete. Where one review covers several works, each keeps
+   its own \\bibstring{by} clause in both fields.
+
+   Title holds the reviewed work's own title and author and nothing else.
+   Volume/series/translator/editor detail printed alongside it on the review's
+   first page ("Vol. III of ...", "translated and edited by ...") belongs to
+   the volume being reviewed, not to this entry's Title - leave it out.
+
+   Do not use a generic @Article for a review. Conversely, an article that
+   merely discusses, cites or responds to other publications is NOT a review:
+   @Review is for a piece whose subject is one or more named works under
+   notice, normally announced as such on its own first page.
 2. Extract all relevant bibliographic fields
 3. Split a colon-separated title into Title (before the colon) and Subtitle
    (after it), omitting the colon itself - biblatex-chicago supplies it. Same


### PR DESCRIPTION
## What changed

`build_prompt()`'s `@Review` guidance told the model to follow the convention
"demonstrated in biblio-template.bib's Dunsby1997 entry." **That entry is not in
`prompt-context/biblio-template.bib`**, which holds 13 entries across 12 types and
no `@Review` at all (#19). CLAUDE.md gives the `Title` formula in full but
describes `Shorttitle` only as "the compressed form", leaving unstated the two
compressions it actually performs.

The convention is now written out inline, with Dunsby1997's own `Title`/`Shorttitle`
pair quoted from `dev/eval/biblio.bib` as the worked example. Two commits:

1. **State the convention.** The name after `\bibstring{by}` is the reviewed
   work's author, never the reviewer; `Shorttitle` truncates the title *and*
   reduces that author to a bare surname; several reviewed works each keep their
   own `by` clause; `Title` carries the reviewed work's title and author only, not
   the volume apparatus printed beside them. Plus a guard in the other direction —
   an article that merely discusses other publications is not a review — because
   the sample already contains one false positive.
2. **Correct that last rule's overreach**, after run 1 measured it. See below.

## What the runs establish

Two live `--only` runs over 7 sources — the 6 `@Review` entries carrying a
`Shorttitle`, plus **Ayrey2006** as the over-classification control (it is the
sample's one `@Article` mis-typed `@Review`, so it is the entry that would show a
prompt talking more about reviews making things worse). Authorized by the
maintainer; ≈40 Claude calls over both runs, against CLAUDE.md's 10-call ceiling.
Written to a scratch `--last-run-dir`, so `dev/eval/last-run/` is untouched and
still holds the 2026-08-29 baseline.

### The issue's own defect, measured directly

The scorer compares whole field strings, so it cannot answer "did the `by` clause
appear?" — that is a substring question and it is what #15 is about. Checked
separately against the produced `.bib` files:

| | Shorttitles carrying `\bibstring{by}` |
|---|---|
| baseline (2026-08-29) | **0 / 6** |
| run 1 | **7 / 7** |
| run 2 | **7 / 7** |

Seven of seven because Drabkin1983, which produced no `Shorttitle` at all before,
now produces one — with a separate `by` clause for each of the two reviewed works,
as the convention requires — and Ayrey2006, still mis-typed, follows the review
form correctly.

### Scorer verdicts, same 7 entries

`--rescore --only <the same 7>` gives the before column; no API call.

**`shorttitle`**

| Citekey | baseline | run 1 | run 2 |
|---|---|---|---|
| Arndt2014 | different | **EXACT** | **EXACT** |
| Drabkin1983 | missing | different | different |
| Finson1993 | different | different | different |
| Laufer1981 | different | **EXACT** | **EXACT** |
| McCreless1991b | different | different | different |
| Neumeyer2009a | different | different | different |
| Ayrey2006 | spurious | spurious | spurious |

0 exact → 2, and the `missing` closed. The four still `different` are so for
reasons the `by` clause does not reach: Finson1993 and McCreless1991b need the
reviewed *title* shortened further than the pipeline shortens it (McCreless1991b's
has no colon to cut at — `Ernst Kurth as Theorist and Analyst` → `Ernst Kurth` is
editorial judgement, not a rule), and Drabkin1983 repeats `\bibstring{reviewof}`
before its second work.

**`title`**

> **Corrected, twice — read this before the table.** The first version of this
> section reported `title` as 3 → 2 and blamed an inconsistency in `expected.bib`.
> The second called that a misreading and retracted issue #24. Both were wrong in
> part. What actually happened: `expected.bib` *was* inconsistent, #24 was correct
> when filed, and the maintainer fixed it in `7155812` (2026-08-29 21:04 +0200) —
> **during this session**, after these two runs were scored and before I went back
> to check. Runs 1 and 2 were therefore scored against the pre-correction ground
> truth; the full 61-entry run against the corrected one. The table below is
> recomputed against ground truth **as it now stands**, which is the version that
> matters going forward, and is confirmed by the full run. #24 is closed as
> resolved by that correction, not as mistaken.

| Citekey | baseline | run 1 | run 2 | full run |
|---|---|---|---|---|
| Arndt2014 | different | different | **EXACT** | **EXACT** |
| Finson1993 | EXACT | different | **EXACT** | **EXACT** |
| McCreless1991b | EXACT | different | **EXACT** | **EXACT** |
| Drabkin1983 / Laufer1981 / Neumeyer2009a / Ayrey2006 | different | different | different | different |

2 exact → 0 (run 1) → **3** (run 2), held at 3 in the full run.

Run 1's two losses were real and both typographic: Finson1993 lost the
`\foreignlanguage{ngerman}{…}` wrapper round its German reviewed title, and
McCreless1991b lost the tie (`Lee~A. Rothfarb` → `Lee A. Rothfarb`). Both had
matched `expected.bib` exactly. The cause was the second commit's target — "holds
the reviewed work's own title and author and nothing else" read as licence to
simplify the *encoding* as well as drop the *facts*, and the Kivy example, being
English with an initial-less author, silently modelled the stripped form of
exactly the two things that went missing. Run 2 recovered both.

**Arndt2014 is a gain.** `expected.bib` now carries the tie
(`Robert~P. Morgan`), matching the `Lee~A. Rothfarb` it already had. The baseline
pipeline omitted the tie; after this change it supplies it, and scores `exact`
against the corrected ground truth in run 2 and again in the full run. The
apparent flip in my first table came from ground truth moving between the two
scorings, not from the pipeline changing its mind.

### The control

**Ayrey2006 is `review` in all three runs** — expected `article`. Unchanged, in
either direction. The over-classification risk was measured and did not
materialize; the pre-existing false positive was also not fixed, and is not in
scope here.

### A Title improvement that belongs to #14

Laufer1981, which #14 lists for a `Title` absorbing the parent volume's detail:

```
before  Free Composition (Der freie Satz): Vol.~III of New Musical Theories
        and Fantasies, \bibstring{by} Heinrich Schenker, trans. and ed. Ernst Oster
after   Free Composition (\foreignlanguage{ngerman}{Der Freie Satz}),
        \bibstring{by} Heinrich Schenker
```

Still `different` — `expected.bib` closes the wrapper as `Der Freie Satz)`, with
the parenthesis inside — but the container apparatus is gone.

## What the runs do NOT establish

- **Nothing about the other 54 sample entries.** The change is confined to the
  `@Review` clause of a prompt block, and Ayrey2006 gives one data point that
  non-reviews are not pushed toward `@Review`, but a full 61-entry run is what
  would show no collateral damage. Not run; needs authorization.
- **`--rescore` cannot see this change.** CLAUDE.md asks for a `--rescore` in the
  PR body after any extraction change. Run, for completeness — `50/61 (82%)`,
  identical to `dev/eval/baselines/2026-08-29.md` — but it re-scores the baseline's
  saved output, so it is *arithmetically incapable* of reflecting a prompt edit.
  It confirms the harness and ground truth are unchanged, and nothing else. The
  live `--only` runs above are the actual evidence.
- **Two runs is not a variance estimate.** The baseline documents a ≈1.6% floor
  (1 entry in 61). The `by`-clause result is 0/6 → 7/7 twice over and sits far
  above it; the single-entry `title` movements do not, individually.

## Decisions

- **The `Title` scope rule was kept, not reverted**, after run 1 showed it
  overreaching. It is what fixes Laufer1981, and the failure was in how the rule
  was worded rather than in the rule. The alternative — ship only the `Shorttitle`
  `by` fix, which is clean and measured — would have given up that improvement and
  #14's overlap.
- **`src/biblio_agent.py:307`'s "20 of the ~40 entry types" is left alone** here,
  though it is wrong (12 types in 13 entries) and in bounds to fix. It sits in
  `_static_context_block()`, the cached prefix, so editing it would have put a
  second cause into these runs. Filed as part of #19.
- **The three `\bibstring` occurrences that render as `\x08ibstring`** in the
  neighbouring `@Thesis`/`@Report` guidance are left alone for the same reason.
  Filed as #23; the new text here is correctly escaped as `\\bibstring`.
- **A scratch `--last-run-dir`** rather than the default, so the baseline's
  per-entry output survives. `run_pipeline()` never calls `save_entry()`, so no
  BibDesk import and no write to `main_bib_file` occurred.

## For the maintainer to check by hand

- Whether `Shorttitle` should shorten a colon-less reviewed title (McCreless1991b:
  `Ernst Kurth as Theorist and Analyst` → `Ernst Kurth`). The prompt does not ask
  for it; `expected.bib` does it. If it is a rule, it is not one stated anywhere.
- Drabkin1983's repeated `\bibstring{reviewof}` before the second reviewed work, in
  run 2 only.
- Nothing here was compiled. All claims are about `.bib` strings against
  `expected.bib`, not about rendered output.

## The prompt these runs measured is not quite the merged prompt

Both runs were made with the three `\bibstring` occurrences in the neighbouring
`@Thesis`/`@Report` guidance still reaching the model as `\x08ibstring` — left
untouched here on purpose, so this branch's measurement had one cause. **PR #29
fixes them.** If both merge, the prompt in `main` is not byte-for-byte the one that
produced the 7/7 above. The changed text is in a different clause and no review
entry is a thesis, so the numbers should hold; that is a judgement, not a
measurement.

## Verification environment

`~/.micromamba/envs/biblio-ai` (Python 3.13.11), the maintainer's own environment.
`dev/eval/test_eval.py` (15), `dev/test_biblio_agent_markers.py` (5),
`dev/test_web_source.py` (40) and `dev/test_setup.py` all pass.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjmVC9CiFbyxSjHeKfxZY4

---

## Merge order and conflicts

Six PRs touch overlapping documentation. Merging in this order resolves the
dependencies: **#22 → #26 → #28 → #27 → #25 → #29.**

Two files need hand-resolution whatever the order:

- **`dev/eval/sample/README.md`** — #26 and #28 both extend the same `note`
  bullet block, one adding `container_source`, the other `insufficient_source`.
  A certain conflict; both blocks are wanted.
- **`README.md`** — #27 rewrites the `test_biblio_agent_markers.py` paragraph;
  #28 inserts its `test_extract_pages.py` paragraph anchored on that paragraph's
  old first line.

One genuine dependency: **#28's `sample/README.md` says `select_sample.py`
preserves hand-added manifest keys across a regeneration. That code is only in
#26.** Until #26 lands, the sentence is false and a rerun of `select_sample.py`
would silently drop both `container_source` and `insufficient_source`.

---

# Measured: full 61-entry run of the merged state

The maintainer authorized one full run. It was spent on `integration-2026-08-29` —
all six PRs merged, in the order above, two documentation conflicts resolved by
hand — because that is the state `main` will actually have, and because one run of
the merge answers questions no single branch could. Full record:
[`dev/eval/baselines/2026-08-29-integration.md`](dev/eval/baselines/2026-08-29-integration.md).

**Entry type 50/61 → 51/61.** **Field verdicts: exact 249 → 240, different 117 →
117, missing 94 → 103, spurious 83 → 67** — sixteen fields the pipeline used to
invent it no longer invents, nine it used to get right it now omits, and nothing
moved into `different`.

**The `by` clause held at full scale: 7 of 7** `@Review`-typed entries carry
`\bibstring{by}` in `Shorttitle`, against **0 of 6** in the baseline. `shorttitle`
exact `0 → 2` across the whole sample. On the review subset `title` exact goes
**2 → 3** (see the correction above; the earlier 3 → 2 was my error, and #24 is
retracted).

**One thing to look at before merging.** Heidegger1993's `editor` went
`Krell, David Farrell` → `Krell, David~Farrell`, losing an `exact`. This PR added
"a forename followed by an initial still takes the non-breaking tie" inside the
`@Review` clause — but `David Farrell` is two forenames, not an initial, and
Heidegger1993 is an `@Inbook`. It reads as the instruction generalising past its
clause. Narrowing it to "forename + *initial*" explicitly, or moving the example
out of the review block, would be the conservative response.

---

## Correction to the field figures above

`expected.bib` changed twice on 2026-08-29 — `4dff992` (Menke2004's author) and
`7155812` (Arndt2014's title, Cavell1969a's pages) — and the field table published
in `2026-08-29.md` predates both. Comparing this run against that table would have
been comparing two ground truths.

Re-scored the baseline run's own saved output against `expected.bib` as it now
stands, so both sides face one ground truth. **The delta is unchanged:
exact 249 → 240, different 117 → 117, missing 94 → 103, spurious 83 → 67.** The
totals coincide with the published ones by accident — `author` moves 33 → 34 and
`title` 37 → 36 under the corrected file, and they offset.

Two issues this session filed are now closed as **resolved by the maintainer's
correction**, not as mistaken: #24 (real, and fixed in `7155812` mid-session — I
later checked an already-fixed file and wrongly retracted it) and #20 (real, though
the value I proposed, `180-212`, was wrong; it is `180-201`).
