### PR TITLE
Mark the four container-source sample entries; sharpen two type rules

### DIFF
--- a/dev/eval/sample/README.md
+++ b/dev/eval/sample/README.md
@@ -40,6 +40,41 @@ A JSON array of objects:
 - `note` (optional) - why this source is in the sample; useful once the
   sample is large enough that the stratification isn't obvious from the
   file list alone.
+- `container_source` (optional) - a sentence saying that the attached file is
+  the whole containing volume rather than the fragment the entry describes,
+  and what the fragment is. Present on four sources so far. See below.
+
+## `container_source`: entries no extraction can score
+
+Four sample entries describe a chapter, essay or introduction whose attached
+PDF is a scan of the entire book:
+
+| Citekey | PDF pages | The entry is |
+|---|---|---|
+| Adorno2011 | 588 | chapter 28 of *Baroque Music* |
+| Roudiez1984 | 310 | a 10-page translator's introduction |
+| Cavell1969a | 197 | one essay |
+| Schenker1994a | 146 | one 8-page essay |
+
+Linking a whole-volume scan to a chapter-level entry is ordinary practice in a
+personal library, and the entries are correct. But the file does not record
+*which* chapter is meant, so no amount of reading further into it recovers the
+answer - a person handed the same PDF and nothing else would fail in the same
+way. The pipeline duly describes the container: all four came back typed
+`collection`, `book`, `book`, `book` in the 2026-08-29 baseline, and the
+correspondence with the page-count ratio is exact.
+
+The key marks them so that a reader of a report knows which failures are the
+pipeline's. Nothing consumes it yet; teaching `run.py` and `scorer.py` to
+honour it belongs with the same decision for a starved source
+([#16](https://github.com/yrammos/biblatex-chicago-claude/issues/16)), which
+proposes `insufficient_source` for a different cause - the file is the right
+one but yields almost no text. The two are kept apart deliberately.
+
+`dev/eval/select_sample.py` carries `container_source`, and any other key it
+did not itself generate, across a regeneration of this file. It computes
+`citekey`, `source`, `sha256` and `note`; everything else belongs to whoever
+wrote it.
 
 ## Composition
 

--- a/dev/eval/sample/manifest.json
+++ b/dev/eval/sample/manifest.json
@@ -9,7 +9,8 @@
   "citekey": "Adorno2011",
   "source": "Adorno2011.pdf",
   "sha256": "2acda2afa7000d78b9f9c7ed77e5eef89ad3456dc96ee8e6f0822faf938ab285",
-  "note": "@incollection — series, translated"
+  "note": "@incollection — series, translated",
+  "container_source": "588-page scan of the whole of Baroque Music; the entry is its chapter 28, and nothing in the file says which chapter is meant."
  },
  {
   "citekey": "Albright2021",
@@ -69,7 +70,8 @@
   "citekey": "Cavell1969a",
   "source": "Cavell1969a.pdf",
   "sha256": "f411abde3cdf16e47096a5a96e0c09a1cbd78d2788362d5d6764c3ea1a80153f",
-  "note": "@inbook — plain (control)"
+  "note": "@inbook — plain (control)",
+  "container_source": "197-page scan of the whole of Must We Mean What We Say?; the entry is one essay from it."
  },
  {
   "citekey": "Dhomont1996",
@@ -285,7 +287,8 @@
   "citekey": "Roudiez1984",
   "source": "Roudiez1984.pdf",
   "sha256": "74ebe3fc3b4ab1ff84266d662fbdc40989ebe59e679d8adfede8d6f644df53ff",
-  "note": "@suppbook — bookauthor, translated"
+  "note": "@suppbook — bookauthor, translated",
+  "container_source": "310-page scan of the whole of Revolution in Poetic Language; the entry is the translator's 10-page introduction."
  },
  {
   "citekey": "Schachter2000",
@@ -303,7 +306,8 @@
   "citekey": "Schenker1994a",
   "source": "Schenker1994a.pdf",
   "sha256": "3f57e3b25e57677a8699085d103805a3313de8ecaf066efaebcccb67eeaa6ca3",
-  "note": "@inbook — series"
+  "note": "@inbook — series",
+  "container_source": "146-page scan of the whole of Das Meisterwerk in der Musik I; the entry is one 8-page essay from it."
  },
  {
   "citekey": "ScienceDirect0",

--- a/dev/eval/select_sample.py
+++ b/dev/eval/select_sample.py
@@ -274,6 +274,35 @@ def select(candidates, quota, seed):
     return chosen, have, by_author
 
 
+# The keys this script computes for every manifest item. Anything else in an
+# existing manifest.json was put there by a person and is carried across a
+# rerun unchanged - see manifest_extras() and dev/eval/sample/README.md.
+GENERATED_MANIFEST_KEYS = frozenset({"citekey", "source", "sha256", "note"})
+
+
+def manifest_extras(manifest_path):
+    """citekey -> {hand-added key: value} from an existing manifest.json.
+
+    Empty for a missing, empty or malformed file: this exists to preserve
+    annotations when there are any, and must never be the reason a fresh
+    selection cannot be written.
+    """
+    try:
+        items = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(items, list):
+        return {}
+    extras = {}
+    for item in items:
+        if not isinstance(item, dict) or "citekey" not in item:
+            continue
+        kept = {k: v for k, v in item.items() if k not in GENERATED_MANIFEST_KEYS}
+        if kept:
+            extras[item["citekey"]] = kept
+    return extras
+
+
 # ── Main ─────────────────────────────────────────────────────────────────
 
 
@@ -383,6 +412,14 @@ def main(argv=None):
     sample_dir = Path(args.sample_dir)
     sample_dir.mkdir(parents=True, exist_ok=True)
 
+    # Keys a person added to the existing manifest by hand, so a rerun does not
+    # silently drop them. Everything this script generates is recomputed;
+    # anything else belongs to whoever wrote it. `container_source` is the case
+    # this was written for - a judgement about the source that no amount of
+    # re-selection can rederive - but the rule is deliberately about unknown
+    # keys in general, not about that one name.
+    kept = manifest_extras(sample_dir / "manifest.json")
+
     manifest, bib_out = [], []
     for c in chosen:
         dest = sample_dir / f"{c['citekey']}{c['path'].suffix.lower()}"
@@ -392,14 +429,14 @@ def main(argv=None):
             if c["feat"]
             else "plain (control)"
         )
-        manifest.append(
-            {
-                "citekey": c["citekey"],
-                "source": dest.name,
-                "sha256": hashlib.sha256(dest.read_bytes()).hexdigest(),
-                "note": note,
-            }
-        )
+        item = {
+            "citekey": c["citekey"],
+            "source": dest.name,
+            "sha256": hashlib.sha256(dest.read_bytes()).hexdigest(),
+            "note": note,
+        }
+        item.update(kept.get(c["citekey"], {}))
+        manifest.append(item)
         # Verbatim source bytes: expected.bib keeps the entry exactly as it was
         # written. Fields the pipeline never produces are excluded at scoring
         # time by scorer.py, not stripped here.

--- a/dev/eval/test_eval.py
+++ b/dev/eval/test_eval.py
@@ -28,6 +28,7 @@ import bib_audit  # noqa: E402
 import run as eval_run  # noqa: E402
 from scorer import score_entry, aggregate, format_report  # noqa: E402
 import populate_sample  # noqa: E402
+import select_sample  # noqa: E402
 
 
 def _entry(text: str) -> bib_audit.Entry:
@@ -404,6 +405,40 @@ def test_load_manifest_reads_json():
     return True
 
 
+def test_manifest_extras_keeps_only_hand_added_keys():
+    """A rerun of select_sample.py recomputes citekey/source/sha256/note and
+    must carry everything else across untouched - `container_source` is a
+    judgement about the source that re-selection cannot rederive, so losing it
+    would be silent and permanent."""
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / 'manifest.json'
+        path.write_text(json.dumps([
+            {"citekey": "A", "source": "A.pdf", "sha256": "deadbeef",
+             "note": "@book — plain (control)", "container_source": "whole volume"},
+            {"citekey": "B", "source": "B.pdf", "note": "@article — plain (control)"},
+        ]), encoding='utf-8')
+        extras = select_sample.manifest_extras(path)
+        # Only the hand-added key survives, and only for the item that had one.
+        assert extras == {"A": {"container_source": "whole volume"}}, extras
+    return True
+
+
+def test_manifest_extras_survives_a_manifest_it_cannot_read():
+    """Preserving annotations must never be the reason a fresh selection
+    cannot be written: absent, malformed and wrong-shaped all yield {}."""
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        assert select_sample.manifest_extras(td / 'nope.json') == {}
+        (td / 'bad.json').write_text('{not json', encoding='utf-8')
+        assert select_sample.manifest_extras(td / 'bad.json') == {}
+        (td / 'object.json').write_text('{"citekey": "A"}', encoding='utf-8')
+        assert select_sample.manifest_extras(td / 'object.json') == {}
+        (td / 'ragged.json').write_text(
+            json.dumps(["a string", {"no": "citekey", "x": 1}]), encoding='utf-8')
+        assert select_sample.manifest_extras(td / 'ragged.json') == {}
+    return True
+
+
 TESTS = [
     test_score_entry_all_verdicts,
     test_score_entry_normalizes_whitespace,
@@ -420,6 +455,8 @@ TESTS = [
     test_main_rescore_only_restricts_to_named_citekeys,
     test_load_manifest_missing_is_empty_not_error,
     test_load_manifest_reads_json,
+    test_manifest_extras_keeps_only_hand_added_keys,
+    test_manifest_extras_survives_a_manifest_it_cannot_read,
 ]
 
 

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -432,9 +432,9 @@ excerpt's text won't (e.g. an embedded Author field):
      because a chapter's opening pages tend to cite the literature heavily.
      If nothing in the given text presents itself as the container, OMIT
      Booktitle rather than supplying a plausible one, exactly as instructed
-     for Location at step 5. An @Incollection or @Inproceedings that is
-     missing its Booktitle is reported as incomplete and can be finished by
-     hand; one carrying a confident wrong Booktitle is not reported at all.
+     for Location at step 5. A field left empty is a gap someone can see and
+     fill; a field filled with the wrong work reads as evidence and will not
+     be questioned.
    - Exception: if the piece is UNTITLED supplemental material (a generic
      preface, foreword, introduction, or index with no title of its own,
      written by someone other than the book's main author) rather than a

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -422,6 +422,14 @@ excerpt's text won't (e.g. an embedded Author field):
      visible in a running header, distinct from the piece's own heading) -
      do NOT use the container's title as the entry's Title when the excerpt
      is clearly one part of a larger work.
+   - Exception: if the piece is UNTITLED supplemental material (a generic
+     preface, foreword, introduction, or index with no title of its own,
+     written by someone other than the book's main author) rather than a
+     titled chapter, use @Suppbook instead (or @Suppcollection for an edited
+     volume) - in that case Title correctly holds the BOOK's own title, with
+     Bookauthor (or Editor/Editora) distinguishing the book's real author
+     from the supplement's Author. Only use @Inbook/@Incollection when the
+     piece has its own distinct title.
    - Booktitle, Booktitleaddon, Eventtitle, Series and the volume's Editor
      must come from the CONTAINER presenting itself as such: a title page, a
      running header or footer, a half-title, a copyright page, a "Proceedings
@@ -435,14 +443,6 @@ excerpt's text won't (e.g. an embedded Author field):
      for Location at step 5. A field left empty is a gap someone can see and
      fill; a field filled with the wrong work reads as evidence and will not
      be questioned.
-   - Exception: if the piece is UNTITLED supplemental material (a generic
-     preface, foreword, introduction, or index with no title of its own,
-     written by someone other than the book's main author) rather than a
-     titled chapter, use @Suppbook instead (or @Suppcollection for an edited
-     volume) - in that case Title correctly holds the BOOK's own title, with
-     Bookauthor (or Editor/Editora) distinguishing the book's real author
-     from the supplement's Author. Only use @Inbook/@Incollection when the
-     piece has its own distinct title.
    If instead the whole source IS the complete work (not one part of a
    larger container) and it has editor(s) but no single author of its own -
    e.g. an edited volume's own landing page, credited "Edited by X and Y"

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -399,6 +399,15 @@ excerpt's text won't (e.g. an embedded Author field):
    - Use @Incollection if it's one chapter of an edited volume where
      different chapters have different authors (an Editor field for the
      volume, distinct from this chapter's Author).
+     An editor's name on the title page is NOT what decides this. Plenty of
+     single-author volumes are edited by someone else - a selection from one
+     writer's work, a collected-essays volume, a critical edition - and those
+     are @Inbook WITH an Editor field, not @Incollection. The question is
+     always who wrote the OTHER contributions: several hands means
+     @Incollection, one hand throughout means @Inbook however prominent the
+     editor is. A title page reading "<Author>, <Title>, edited by <Editor>",
+     or a series list on the endpapers naming only that one author's books,
+     both point to @Inbook.
    - Use @Inproceedings if it's one paper within a conference proceedings
      volume (Booktitle = the proceedings volume, Booktitleaddon = the
      conference name/location if given). The discriminator against
@@ -413,6 +422,19 @@ excerpt's text won't (e.g. an embedded Author field):
      visible in a running header, distinct from the piece's own heading) -
      do NOT use the container's title as the entry's Title when the excerpt
      is clearly one part of a larger work.
+   - Booktitle, Booktitleaddon, Eventtitle, Series and the volume's Editor
+     must come from the CONTAINER presenting itself as such: a title page, a
+     running header or footer, a half-title, a copyright page, a "Proceedings
+     of ..." or series statement. A book, journal or conference NAMED IN THE
+     BODY TEXT - discussed, quoted, cited, or sitting in a reference list -
+     is a work this piece talks about, not the volume it appears in, and must
+     never be used for these fields. The two are easy to confuse precisely
+     because a chapter's opening pages tend to cite the literature heavily.
+     If nothing in the given text presents itself as the container, OMIT
+     Booktitle rather than supplying a plausible one, exactly as instructed
+     for Location at step 5. An @Incollection or @Inproceedings that is
+     missing its Booktitle is reported as incomplete and can be finished by
+     hand; one carrying a confident wrong Booktitle is not reported at all.
    - Exception: if the piece is UNTITLED supplemental material (a generic
      preface, foreword, introduction, or index with no title of its own,
      written by someone other than the book's main author) rather than a


### PR DESCRIPTION
## The measurement that splits this issue

Page count of every sample PDF against its expected `pages` span. Free, and
decisive:

| Citekey | PDF pages | Expected `pages` | Ratio |
|---|---|---|---|
| Adorno2011 | 588 | (none; `chapter = 28`) | whole volume |
| Roudiez1984 | 310 | 1-10 | **31.0** |
| Schenker1994a | 146 | 31-38 | **18.2** |
| Cavell1969a | 197 | 180-201 | **≈9.0** |
| Kranenburg2008 | 17 | 120-137 | 0.9 |
| Gollin2011a | 3 | 579-581 | 1.0 |
| Laufer1981 | 28 | 158-184 | 1.0 |
| Heidegger1993 | 25 | 149-187 | 0.6 |
| Monelle2008 | 12 | 23-45 | 0.5 |

Every *other* entry in the 61-entry sample with a parseable range sits at ≈1.

Cavell1969a's range read `180-2012` when this table was first computed — a
ground-truth typo, filed as #20 and since corrected by the maintainer to `180-201`
in `7155812`. The row above uses the corrected value. My own guess at the true
range (`180-212`) was wrong; the finding rests on 2012 being impossible in a
197-page file, which is the part that was checkable from here.

The four far above 1 are exactly the four whose produced type was the container's
(`collection`, `book`, `book`, `book`). The correspondence is exact.

## Half of #14 cannot be built, and this says so

The issue proposes that "extraction needs to locate the fragment's own start
before applying the ~450-word budget." For those four that fix is not available:
the file does not record *which* fragment is meant. `Adorno2011.pdf` is 588 pages
of *Baroque Music*; the entry is its chapter 28, and nothing in the file says
chapter 28 rather than 3 or 19. Reading further recovers an intention that was
never written down. A person handed the same PDF and no other instruction would
fail identically.

Linking a whole-volume scan to a chapter-level entry is ordinary practice in a
personal library, and all four entries are correct. What they are not is
scoreable.

**So they are marked, not fixed.** `manifest.json` gains a `container_source`
key on each — a sentence naming the volume and the fragment — and
`dev/eval/sample/README.md` explains it. Nothing consumes the key yet.

## The other half: two prompt rules, both narrow

Of the remaining five: **Gollin2011a scored correct in run 2** (it is the
baseline's own documented variance instance) and **Laufer1981's type was already
right** — its complaint is a `Title`, which PR #25 fixes. Three left. Reading
their extracted text — free, `extract_pdf()` directly — shows only two are
reachable at all:

**Heidegger1993** (`@inbook` read as `@incollection`). Page 1 carries everything
needed: `MARTIN HEIDEGGER / BASIC WRITINGS … EDITED, WITH GENERAL INTRODUCTION
AND INTRODUCTIONS TO EACH SELECTION BY DAVID FARRELL KRELL`, plus an endpaper
list of Heidegger's own books. The model took the editor's presence as the
discriminator. The prompt now says an editor's name on the title page decides
nothing — the question is who wrote the *other* contributions, and a
single-author volume edited by someone else is `@Inbook` **with** an `Editor`.

**Monelle2008** (`@inproceedings` read as `@incollection`). Its `Booktitle` came
back `Music and Urban Geography` — Adam Krims's book, which Monelle's paper
discusses in its opening paragraphs. The proceedings volume's own title
(`Before and after Music`) appears nowhere in the extracted text. The prompt now
says `Booktitle`, `Booktitleaddon`, `Eventtitle`, `Series` and the volume's
`Editor` must come from the container presenting itself as such — title page,
running header, half-title, "Proceedings of …" statement — and never from a work
named in the body; and that an unnameable container means **omitting**
`Booktitle`. That is step 5's `Location` rule applied to the fields that lacked
it, and it trades a confident wrong value for an `% INCOMPLETE:` report.

**Kranenburg2008** (`@incollection` read as `@article`) is deliberately left
alone. Neither the volume title (`Tonal Theory for the Digital Age`) nor its
three editors appear in the extracted text. The model saw a numbered serial and
produced `@article` with `Journaltitle = {Computing in Musicology}`, which on the
evidence available to it is defensible. Any rule that "fixed" this would be
guessing at information the source does not carry — the same fault as the four
above, one size down.

## What is tested, and what is assumed

**Tested.** `manifest_extras()`, added to `select_sample.py`, has two self-tests
in `dev/eval/test_eval.py` (17 pass, up from 15):

- only hand-added keys survive; `citekey`/`source`/`sha256`/`note` are dropped
  because the script recomputes them;
- a missing, malformed, wrong-shaped or ragged manifest yields `{}` rather than
  an exception — preserving annotations must never be the reason a fresh
  selection cannot be written.

This matters because `select_sample.py` rebuilt `manifest.json` wholesale. A
hand-added `container_source` would have been destroyed by the next
regeneration, silently, with nothing afterwards to show anything had been there.

**Assumed.** *Both prompt rules are unverified.* Two entries against the
baseline's documented ≈1.6% noise floor (1 entry in 61) cannot be resolved by a
targeted run: a 2-entry improvement and a 2-entry coin flip look identical. What
would settle it is a full 61-entry run against `dev/eval/baselines/2026-08-29.md`,
which is not this session's to authorize. The rules are argued from the sources'
actual extracted text, which is the strongest evidence available without paying
for one.

**`--rescore`**: `50/61 (82%)`, identical to the baseline. As in PR #25, this
re-scores the baseline's *saved output* and is arithmetically incapable of
reflecting a prompt change. It confirms the harness, the ground truth and the
manifest edit are all still consistent — the manifest gained a key without
disturbing scoring — and nothing more.

## Decisions

- **`container_source` carries a sentence, not `true`.** A self-documenting value
  cannot drift out of step with a separate reason field, and a consumer's
  `if item.get('container_source')` reads the same either way. #16 proposes
  `insufficient_source` for the different cause (right file, almost no text);
  the names are kept apart on purpose so a report can tell them apart.
- **Nothing yet consumes the key.** Teaching `run.py`/`scorer.py` to exclude
  these from field accuracy, and to score instead on whether the pipeline
  declines, is #16's proposal 2 and needs the same decision for both causes.
  Building it here would settle that question in the wrong PR.
- **`select_sample.py` preserves unknown keys rather than a named list.** The
  rule is about anything a person wrote, not about `container_source`
  specifically. The alternative — documenting "reruns destroy annotations" in the
  README and leaving it — is precisely this project's recurring failure shape.
- **The four are left in the sample.** Removing them would flatter the type
  accuracy by 4 entries while hiding a real limit of the harness.

## For the maintainer to check by hand

- Whether `Adorno2011`, `Cavell1969a`, `Roudiez1984` and `Schenker1994a` really
  are whole-volume attachments as claimed — page counts and `local-url` filenames
  say so, but you own the library.
- **#20** — Cavell1969a's `pages = {180-2012}`.
- Whether an `@Incollection` with no `Booktitle` at all is genuinely preferable to
  a wrong one. The `% INCOMPLETE:` path reports it, so it should be; it is a
  judgement about your workflow, not about the code.
- Nothing here was compiled, and no entry was written to BibDesk or to
  `main_bib_file`.

## Verification environment

`~/.micromamba/envs/biblio-ai` (Python 3.13.11). `dev/eval/test_eval.py` (17),
`dev/test_biblio_agent_markers.py` (5), `dev/test_web_source.py` (40) and
`dev/test_setup.py` all pass. No API calls were made on this branch.

## Why this is `Refs` and not a closing keyword

Deliberately `Refs`. This PR builds two of the nine cases the issue lists and
argues that four of them cannot be built at all — which is a claim about the
issue's premise, not a completion of it. Given how #7 was handled, whether that
argument holds, and whether the issue should close on it, reads as the
maintainer's call rather than something a merge should decide silently. The
remaining case (Kranenburg2008) is explained above and left alone.

Refs #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjmVC9CiFbyxSjHeKfxZY4

---

## Merge order and conflicts

Six PRs touch overlapping documentation. Merging in this order resolves the
dependencies: **#22 → #26 → #28 → #27 → #25 → #29.**

Two files need hand-resolution whatever the order:

- **`dev/eval/sample/README.md`** — #26 and #28 both extend the same `note`
  bullet block, one adding `container_source`, the other `insufficient_source`.
  A certain conflict; both blocks are wanted.
- **`README.md`** — #27 rewrites the `test_biblio_agent_markers.py` paragraph;
  #28 inserts its `test_extract_pages.py` paragraph anchored on that paragraph's
  old first line.

One genuine dependency: **#28's `sample/README.md` says `select_sample.py`
preserves hand-added manifest keys across a regeneration. That code is only in
#26.** Until #26 lands, the sentence is false and a rerun of `select_sample.py`
would silently drop both `container_source` and `insufficient_source`.

---

# Measured: full 61-entry run of the merged state

The maintainer authorized one full run. It was spent on `integration-2026-08-29` —
all six PRs merged, in the order above, two documentation conflicts resolved by
hand — because that is the state `main` will actually have, and because one run of
the merge answers questions no single branch could. Full record:
[`dev/eval/baselines/2026-08-29-integration.md`](dev/eval/baselines/2026-08-29-integration.md).

**Entry type 50/61 → 51/61.** **Field verdicts: exact 249 → 240, different 117 →
117, missing 94 → 103, spurious 83 → 67** — sixteen fields the pipeline used to
invent it no longer invents, nine it used to get right it now omits, and nothing
moved into `different`.

**Rule 1 works.** Heidegger1993: `incollection` → **`inbook`**, the whole of the
type improvement. Kranenburg2008, deliberately not attempted, did not move;
Monelle2008's proceedings volume is still named nowhere in its text.

**Rule 2 is the omission trade, and it is the thing to decide before merging.**
`spurious −16`, `missing +9`, `exact −9`, `different 0`. Good: `entrysubtype`
spurious `7 → 1`, `chapter` `2 → 0`, `publisher` `4 → 2`, Ericson2022's wrong
`booktitle` and Krebs1980's invented `location` both gone. Bad: Greenhead2016
`pages`, Zemtsovsky2016 `booksubtitle` and Gollin2011a `location`/`publisher` went
from `exact` to `missing`. This PR's own text argues the trade is worth making;
the run puts numbers on it, and the call is yours.

**One specific concern.** Gollin2011a — a `@Suppbook` glossary contribution —
degraded: `title` became `Glossary` rather than the book's title, which is the
`@Suppbook` convention being lost. Its type is still correct, and the baseline
names this entry as its one unattributable flip, so it is not clean evidence. But
the editor-discriminator text added here sits directly adjacent to the `@Suppbook`
exception in the prompt, and dilution is a plausible mechanism. Worth reading those
two clauses together before merging.

**The four container-source entries did not move**, as expected — nothing here
tried to move them, and nothing could.

---

## Correction to the field figures above

`expected.bib` changed twice on 2026-08-29 — `4dff992` (Menke2004's author) and
`7155812` (Arndt2014's title, Cavell1969a's pages) — and the field table published
in `2026-08-29.md` predates both. Comparing this run against that table would have
been comparing two ground truths.

Re-scored the baseline run's own saved output against `expected.bib` as it now
stands, so both sides face one ground truth. **The delta is unchanged:
exact 249 → 240, different 117 → 117, missing 94 → 103, spurious 83 → 67.** The
totals coincide with the published ones by accident — `author` moves 33 → 34 and
`title` 37 → 36 under the corrected file, and they offset.

Two issues this session filed are now closed as **resolved by the maintainer's
correction**, not as mistaken: #24 (real, and fixed in `7155812` mid-session — I
later checked an already-fixed file and wrongly retracted it) and #20 (real, though
the value I proposed, `180-212`, was wrong; it is `180-201`).
