### PR TITLE
Return extraction state alongside the entry, not embedded in it

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,9 +95,15 @@ fallback and plausibility check (including the amber-vs-fail split) against cann
 fixtures - the live failures it guards against (an actual bot challenge, a half-loaded
 tab) can't be staged by hand.
 
-`python3 dev/test_biblio_agent_markers.py` self-tests `save_entry()`'s marker
-extraction/reattachment - in particular that the `% AMBER: ...` comment a thin/sparse
-`.webloc` source needs (see above) actually survives into the saved `.bib` text.
+`python3 dev/test_biblio_agent_markers.py` self-tests what `save_entry()` writes -
+in particular that the `% AMBER: ...` comment a thin/sparse `.webloc` source needs
+(see above) actually survives into the saved `.bib` text, and that the review colour
+reaches BibDesk on the other branch. It also runs `extract_bibtex()` end to end, with
+only the API call stubbed, so a state the extractor stops populating fails a test
+rather than passing quietly: the review state travels from one to the other as an
+`ExtractionResult` (`src/extraction_result.py`), and the `%` comments are rendered at
+the point of writing. They were formerly prepended to the entry text and parsed back
+out positionally, which is how the amber colouring failed silently for a month.
 
 ## Configuration
 
@@ -333,6 +339,7 @@ ostracon-ai/
 ├── requirements.txt
 ├── src/
 │   ├── biblio_agent.py     # Orchestrator; run this
+│   ├── extraction_result.py # What extract_bibtex() hands save_entry()
 │   ├── extract_pages.py    # PDF text and OCR
 │   ├── web_source.py       # .webloc page fetching
 │   ├── enrich.py           # CrossRef/Scholar lookups and reconciliation

--- a/dev/eval/run.py
+++ b/dev/eval/run.py
@@ -97,13 +97,13 @@ def run_pipeline(agent, source_path, citekey=None, save_dir=None) -> "bib_audit.
     are given - see load_last_run()/--rescore.
     """
     label = f"{citekey}: " if citekey else ""
-    bibtex_entry = agent.extract_bibtex(source_path)
-    if bibtex_entry.startswith("Error:"):
-        print(f"   ⚠️  {label}{bibtex_entry}", file=sys.stderr)
-        clean = f"% extraction failed: {bibtex_entry}\n"
+    result = agent.extract_bibtex(source_path)
+    if result.failed:
+        print(f"   ⚠️  {label}{result.error}", file=sys.stderr)
+        clean = f"% extraction failed: {result.error}\n"
         entry = None
     else:
-        clean = agent.clean_bibtex(bibtex_entry)
+        clean = agent.clean_bibtex(result.entry)
         entries, _ = bib_audit.scan(clean)
         entry = entries[0] if entries else None
         if entry is None:

--- a/dev/eval/test_eval.py
+++ b/dev/eval/test_eval.py
@@ -28,6 +28,7 @@ import bib_audit  # noqa: E402
 import run as eval_run  # noqa: E402
 from scorer import score_entry, aggregate, format_report  # noqa: E402
 import populate_sample  # noqa: E402
+from extraction_result import ExtractionResult  # noqa: E402
 
 
 def _entry(text: str) -> bib_audit.Entry:
@@ -268,13 +269,23 @@ def test_evaluate_end_to_end():
 
 class _FakeAgent:
     """Stands in for biblio_agent.BiblioAgent's two methods run_pipeline()
-    calls - enough to test the save/reload round trip without the API."""
+    calls - enough to test the save/reload round trip without the API.
+
+    extract_bibtex() returns a real ExtractionResult, not a look-alike. A stub
+    encodes the format the author expected rather than the one the system
+    emits, which is how a live fault survived a round of testing here before;
+    importing the actual class removes the gap. extraction_result.py depends on
+    nothing outside the standard library, so this costs the file none of its
+    "no anthropic, no config.yaml" independence."""
 
     def __init__(self, bibtex_by_source):
         self._bibtex_by_source = bibtex_by_source
 
     def extract_bibtex(self, source_path):
-        return self._bibtex_by_source[source_path.name]
+        text = self._bibtex_by_source[source_path.name]
+        if text.startswith("Error:"):
+            return ExtractionResult(error=text)
+        return ExtractionResult(entry=text, source_label=f"PDF ({source_path.name})")
 
     def clean_bibtex(self, bibtex_entry):
         return bibtex_entry

--- a/dev/test_biblio_agent_markers.py
+++ b/dev/test_biblio_agent_markers.py
@@ -1,18 +1,29 @@
 #!/usr/bin/env python3
 """
-Regression test for BiblioAgent.save_entry()'s marker extraction/reattachment
-- specifically the "% AMBER: ..." comment web_source.py's content-plausibility
-follow-up relies on to survive into the saved .bib text for a .webloc source
-(never fileable, so it never reaches BibDesk's own color - see save_entry).
+Regression test for what BiblioAgent.save_entry() writes - specifically the
+"% AMBER: ..." comment web_source.py's content-plausibility follow-up relies
+on to survive into the saved .bib text for a .webloc source (never fileable,
+so it never reaches BibDesk's own color - see save_entry), and the review
+color reaching BibDesk on the other branch.
 
-Found in passing while adding that marker: the pre-existing "% Source: ..."
-regex placed its \\b word-boundary assertion right after the literal colon
-(`Source:\\b`), which can never match (a non-word character can't start a
-word boundary against another non-word character) - so source_comment was
-always empty, and clean_bibtex()'s "strip everything before the first @"
-silently discarded the "% Source: ..." comment from every saved entry. Fixed
-alongside the new "% AMBER: ..." marker, which was written with the same
-mistake and would otherwise have failed exactly the same way, invisibly.
+These tests were written against the marker protocol: save_entry() took a
+string with up to four "%" markers prepended, and recovered the state by
+matching each positionally with an anchored re.match. That protocol is gone
+(issue #18) - state now arrives as an ExtractionResult, and the comments are
+rendered at the point of writing rather than parsed out of the text. What the
+tests assert is unchanged, because they always asserted on what reaches the
+saved file and on the kwargs BibDesk is called with, not on the markers. Only
+how each fixture is built has changed: an ExtractionResult, not a prefixed
+string.
+
+The fault they were written for is worth restating, since it is what the
+refactor removes. The "% Source: ..." regex placed its \\b word-boundary
+assertion right after the literal colon (`Source:\\b`), which can never match.
+Because that marker was outermost and re.match anchors at position 0, every
+matcher below it then ran against a string still starting "% Source:" and
+failed too - so needs_color was False for every entry and every source type,
+and BibDesk's amber coloring was inert from 2026-07-30 until it was found. See
+issue #17 for the affected window.
 
 No API call, no network: uses config.yaml as-is (BiblioAgent's __init__
 constructs an Anthropic client but never calls it here), redirected to a
@@ -56,28 +67,30 @@ def _capture_bibdesk(agent):
 
 
 def test_source_and_amber_comments_survive_needs_color_flag_is_discarded():
-    entry_text = (
-        "% Source: webpage (https://example.org/x)\n"
-        "% NEEDS_COLOR_FLAG\n"
-        "% AMBER: no Author/Doi/PublicationDate - only Urldate available to date it\n"
-        "@Online{MarkerTest2026,\n"
-        "  Title = {A Study of Musical Form},\n"
-        "  Urldate = {2026-08-29},\n"
-        "}\n"
+    result = biblio_agent.ExtractionResult(
+        entry=(
+            "@Online{MarkerTest2026,\n"
+            "  Title = {A Study of Musical Form},\n"
+            "  Urldate = {2026-08-29},\n"
+            "}\n"
+        ),
+        source_label="webpage (https://example.org/x)",
+        needs_color=True,
+        amber_reason="no Author/Doi/PublicationDate - only Urldate available to date it",
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
         agent = _agent(bib_path)
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "smoketest.webloc")
+            ok = agent.save_entry(result, "smoketest.webloc")
         saved = bib_path.read_text(encoding="utf-8")
 
     assert ok is True
     # NEEDS_COLOR_FLAG is internal bookkeeping only - must not reach the file.
     assert "NEEDS_COLOR_FLAG" not in saved, saved
     # Both comments that ARE meant to persist must actually be there, in the
-    # order extract_bibtex() prepends them (Source outermost, AMBER next).
+    # order comment_lines() renders them (Source outermost, AMBER next).
     assert saved.index("% Source:") < saved.index("% AMBER:") < saved.index("@Online"), saved
     assert "% AMBER: no Author/Doi/PublicationDate" in saved, saved
     assert "@Online{MarkerTest2026," in saved, saved
@@ -91,19 +104,21 @@ def test_entry_without_amber_marker_is_unaffected():
     # A plain PDF-sourced entry (no AMBER marker at all) must still save
     # correctly and keep its Source comment - the fix must not have broken
     # the common case while fixing the broken one.
-    entry_text = (
-        "% Source: PDF (paper.pdf)\n"
-        "@Article{PlainTest2026,\n"
-        "  Title = {An Ordinary Article},\n"
-        "  Author = {Doe, Jane},\n"
-        "}\n"
+    result = biblio_agent.ExtractionResult(
+        entry=(
+            "@Article{PlainTest2026,\n"
+            "  Title = {An Ordinary Article},\n"
+            "  Author = {Doe, Jane},\n"
+            "}\n"
+        ),
+        source_label="PDF (paper.pdf)",
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
         agent = _agent(bib_path)
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "plaintest.pdf")
+            ok = agent.save_entry(result, "plaintest.pdf")
         saved = bib_path.read_text(encoding="utf-8")
 
     assert ok is True
@@ -119,11 +134,11 @@ def test_webloc_reaches_bibdesk_and_is_colored_without_auto_file():
     # the amber flag - and a .webloc entry used to be excluded from the import
     # path entirely, so it got neither. It must now be imported and colored,
     # with only `auto file` withheld (there is no document to file).
-    entry_text = (
-        "% Source: webpage (https://example.org/x)\n"
-        "% NEEDS_COLOR_FLAG\n"
-        "% AMBER: no Author/Doi/PublicationDate - only Urldate available to date it\n"
-        "@Online{WeblocTest2026,\n  Title = {A Study of Musical Form},\n}\n"
+    result = biblio_agent.ExtractionResult(
+        entry="@Online{WeblocTest2026,\n  Title = {A Study of Musical Form},\n}\n",
+        source_label="webpage (https://example.org/x)",
+        needs_color=True,
+        amber_reason="no Author/Doi/PublicationDate - only Urldate available to date it",
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
@@ -131,7 +146,7 @@ def test_webloc_reaches_bibdesk_and_is_colored_without_auto_file():
         calls = _capture_bibdesk(agent)
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "smoketest.webloc")
+            ok = agent.save_entry(result, "smoketest.webloc")
 
     assert ok is True
     assert calls, "a .webloc entry never reached _save_via_bibdesk"
@@ -146,10 +161,10 @@ def test_pdf_still_auto_files():
     # The other side of the same split: a PDF has a document, so auto_file
     # stays on. Guards against "fix the .webloc case, silently stop filing
     # every PDF."
-    entry_text = (
-        "% Source: PDF (paper.pdf)\n"
-        "% NEEDS_COLOR_FLAG\n"
-        "@Article{PdfTest2026,\n  Title = {An Ordinary Article},\n  Author = {Doe, Jane},\n}\n"
+    result = biblio_agent.ExtractionResult(
+        entry="@Article{PdfTest2026,\n  Title = {An Ordinary Article},\n  Author = {Doe, Jane},\n}\n",
+        source_label="PDF (paper.pdf)",
+        needs_color=True,
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
@@ -160,7 +175,7 @@ def test_pdf_still_auto_files():
         agent.add_bdsk_bookmark = lambda entry, path: entry
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "paper.pdf")
+            ok = agent.save_entry(result, "paper.pdf")
 
     assert ok is True
     assert calls["auto_file"] is True, calls
@@ -171,9 +186,9 @@ def test_pdf_still_auto_files():
 def test_no_color_flag_means_no_color():
     # needs_color must not become sticky: an entry carrying no
     # NEEDS_COLOR_FLAG has to reach BibDesk uncolored.
-    entry_text = (
-        "% Source: webpage (https://example.org/x)\n"
-        "@Online{CleanTest2026,\n  Title = {A Study of Musical Form},\n}\n"
+    result = biblio_agent.ExtractionResult(
+        entry="@Online{CleanTest2026,\n  Title = {A Study of Musical Form},\n}\n",
+        source_label="webpage (https://example.org/x)",
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
@@ -181,10 +196,126 @@ def test_no_color_flag_means_no_color():
         calls = _capture_bibdesk(agent)
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "clean.webloc")
+            ok = agent.save_entry(result, "clean.webloc")
 
     assert ok is True
     assert calls["needs_color"] is False, calls
+    return True
+
+
+def test_field_sources_reaches_the_saved_text():
+    # enrich_entry()'s per-field provenance was the one marker with no
+    # coverage at all, and it is the marker that sat innermost - so under the
+    # old positional protocol it was the first to be lost whenever anything
+    # above it failed to match, and nothing would have said so.
+    result = biblio_agent.ExtractionResult(
+        entry="@Article{SourcesTest2026,\n  Title = {An Ordinary Article},\n  Author = {Doe, Jane},\n}\n",
+        source_label="PDF (paper.pdf)",
+        field_sources="PDF: title, author; CrossRef: volume, pages",
+    )
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        agent = _agent(bib_path)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            ok = agent.save_entry(result, "paper.pdf")
+        saved = bib_path.read_text(encoding="utf-8")
+
+    assert ok is True
+    assert "% Sources -- PDF: title, author; CrossRef: volume, pages" in saved, saved
+    # Innermost of the three: after Source, immediately before the entry.
+    assert saved.index("% Source:") < saved.index("% Sources --") < saved.index("@Article"), saved
+    return True
+
+
+def test_comment_lines_order_and_omission():
+    # The rendering order is the contract the two assertions above depend on,
+    # and it is worth asserting directly rather than only through the file.
+    # needs_color must never appear: it is a colour, not a comment, and
+    # writing it was what the old NEEDS_COLOR_FLAG marker had to undo.
+    full = biblio_agent.ExtractionResult(
+        entry="@Book{X,}", source_label="PDF (a.pdf)", needs_color=True,
+        amber_reason="thin source", field_sources="CrossRef: date",
+    )
+    assert full.comment_lines() == [
+        "% Source: PDF (a.pdf)",
+        "% AMBER: thin source",
+        "% Sources -- CrossRef: date",
+    ], full.comment_lines()
+
+    # Absent state contributes no line at all - not an empty one.
+    assert biblio_agent.ExtractionResult(entry="@Book{X,}").comment_lines() == []
+    assert biblio_agent.ExtractionResult(
+        entry="@Book{X,}", needs_color=True).comment_lines() == []
+
+    # A failed result reports itself as failed and carries the reason.
+    failed = biblio_agent.ExtractionResult(error="Error: File not found: x.pdf")
+    assert failed.failed is True
+    assert biblio_agent.ExtractionResult(entry="@Book{X,}").failed is False
+    return True
+
+
+def test_extract_bibtex_to_save_entry_round_trip():
+    """The join the old protocol had no coverage of at all.
+
+    Every test above builds its own ExtractionResult, so all of them would
+    keep passing if extract_bibtex() stopped populating one - which is the
+    exact shape of the fault this refactor is for. This one runs the real
+    extract_bibtex(), with only the network stubbed, and feeds what it
+    returns straight to save_entry().
+
+    Stubbed: the Anthropic call, and a `.fake` source extractor registered in
+    EXTRACTORS so no PDF or webpage is needed. Not stubbed: prompt building,
+    forbidden-field stripping, the amber fold-in, the result construction,
+    and all of save_entry.
+    """
+    import extract_pages
+
+    class _Msg:
+        content = [type("B", (), {"type": "text",
+                                  "text": "@Online{RoundTrip2026,\n  Title = {A Study of Musical Form},\n}"})()]
+
+    class _Messages:
+        def create(self, **kwargs):
+            return _Msg()
+
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        source = Path(td) / "thin.fake"
+        source.write_text("placeholder", encoding="utf-8")
+
+        agent = _agent(bib_path)
+        # No enrichment: that path makes its own network calls, and the join
+        # under test is extract_bibtex -> save_entry, not CrossRef.
+        agent.config["enrich_missing_fields"] = False
+        agent.client = type("C", (), {"messages": _Messages()})()
+
+        biblio_agent.EXTRACTORS[".fake"] = lambda path, **kw: extract_pages.SourceContent(
+            text="some body text", label="webpage", url="https://example.org/x",
+            amber=True, amber_reason="short body",
+        )
+        try:
+            err = io.StringIO()
+            with redirect_stderr(err):
+                result = agent.extract_bibtex(source)
+                ok = agent.save_entry(result, source)
+        finally:
+            del biblio_agent.EXTRACTORS[".fake"]
+
+        saved = bib_path.read_text(encoding="utf-8")
+
+    # extract_bibtex actually populated the state, rather than the test
+    # asserting a shape it invented itself.
+    assert result.failed is False, result
+    assert result.source_label == "webpage (https://example.org/x)", result
+    assert result.amber_reason == "short body", result
+    assert result.needs_color is True, result
+    # ...and every bit of it that should reach the file did.
+    assert ok is True
+    assert "% Source: webpage (https://example.org/x)" in saved, saved
+    assert "% AMBER: short body" in saved, saved
+    assert "NEEDS_COLOR_FLAG" not in saved, saved
+    assert "@Online{RoundTrip2026," in saved, saved
     return True
 
 
@@ -194,6 +325,9 @@ TESTS = [
     test_webloc_reaches_bibdesk_and_is_colored_without_auto_file,
     test_pdf_still_auto_files,
     test_no_color_flag_means_no_color,
+    test_field_sources_reaches_the_saved_text,
+    test_comment_lines_order_and_omission,
+    test_extract_bibtex_to_save_entry_round_trip,
 ]
 
 

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -15,6 +15,7 @@ import yaml
 from anthropic import Anthropic
 
 from extract_pages import extract_pdf
+from extraction_result import ExtractionResult
 import web_source
 import enrich
 
@@ -535,16 +536,20 @@ excerpt's text won't (e.g. an embedded Author field):
                 config['model'] - for pdf-in/careful/ sources (see process_batch).
 
         Returns:
-            str: BibLaTeX entry or error message
+            ExtractionResult: the entry text plus the review state that
+            belongs to it (source label, needs_color, amber reason, field
+            provenance), or one carrying `error`. The state used to travel as
+            `%` markers prepended to the text and parsed back out by
+            save_entry(); see extraction_result.py for why it no longer does.
         """
         path = Path(path)
 
         if not path.exists():
-            return f"Error: File not found: {path}"
+            return ExtractionResult(error=f"Error: File not found: {path}")
 
         extractor = EXTRACTORS.get(path.suffix.lower())
         if extractor is None:
-            return f"Error: Unsupported file type: {path.name}"
+            return ExtractionResult(error=f"Error: Unsupported file type: {path.name}")
 
         if batch_info:
             i, total = batch_info
@@ -575,7 +580,7 @@ excerpt's text won't (e.g. an embedded Author field):
         content = extractor(path, **kwargs)
 
         if isinstance(content, str):  # error message
-            return content
+            return ExtractionResult(error=content)
 
         # Load context files
         self._log("   Loading context...", 'info')
@@ -612,8 +617,9 @@ excerpt's text won't (e.g. an embedded Author field):
                 self._log(f"   Stripped disallowed field(s): {', '.join(stripped)}", 'warning')
 
             needs_color = False
+            field_sources = None
             if self.config.get('enrich_missing_fields', True):
-                bibtex_entry = self.enrich_entry(bibtex_entry, content)
+                bibtex_entry, field_sources = self.enrich_entry(bibtex_entry, content)
                 bibtex_entry, needs_color = self.verify_and_flag_recollection(bibtex_entry, content)
 
             # content.amber is web_source.py's plausibility check flagging a
@@ -622,27 +628,29 @@ excerpt's text won't (e.g. an embedded Author field):
             # just worth a glance. Folded into the same needs_color signal a
             # recollection-audit failure uses, so it reaches BibDesk's review
             # color by exactly the path a PDF's review state does. The
-            # additional "% AMBER: ..." comment carries the same flag on the
-            # other branch, where entries are appended as text and no color
-            # is possible; each survives where the other cannot (see
-            # save_entry).
+            # "% AMBER: ..." comment save_entry writes from amber_reason
+            # carries the same flag on the other branch, where entries are
+            # appended as text and no color is possible; each survives where
+            # the other cannot.
+            amber_reason = None
             if content.amber:
                 needs_color = True
+                amber_reason = content.amber_reason
                 self._log(f"   ⚠️  Thin/sparse source ({content.amber_reason}) - flagging for review", 'warning')
-                bibtex_entry = f"% AMBER: {content.amber_reason}\n" + bibtex_entry
-
-            if needs_color:
-                bibtex_entry = "% NEEDS_COLOR_FLAG\n" + bibtex_entry
-
-            bibtex_entry = f"% Source: {content.label} ({content.url or path.name})\n" + bibtex_entry
 
             self._log("   Validating entry...", 'info')
             self._log("   ✓ Complete", 'success')
 
-            return bibtex_entry
+            return ExtractionResult(
+                entry=bibtex_entry,
+                source_label=f"{content.label} ({content.url or path.name})",
+                needs_color=needs_color,
+                amber_reason=amber_reason,
+                field_sources=field_sources,
+            )
 
         except Exception as e:
-            return f"Error: {e}"
+            return ExtractionResult(error=f"Error: {e}")
 
     def _build_enrich_prompt(self, entry, found_fields):
         """Build a prompt asking Claude to merge externally-sourced fields
@@ -680,14 +688,19 @@ commentary."""
             entry_text: The BibLaTeX entry produced so far
             content: The SourceContent (PDF or webpage) the entry was drawn from
 
-        Returns the (possibly unchanged) entry text.
+        Returns (entry_text, field_sources): the possibly-unchanged entry, and
+        a one-line per-field provenance summary, or None when nothing was
+        enriched. The summary used to be prepended to the returned text as a
+        "% Sources -- ..." comment and sliced back off by save_entry(); it is
+        now returned beside the text and rendered once, at the point of
+        writing. See extraction_result.py.
         """
         entry_type = enrich.get_entry_type(entry_text)
         fields = enrich.parse_bibtex_fields(entry_text)
         required, desired = enrich.missing_fields(entry_type, fields)
         if not required and not desired:
             self._log(f"   Source: {content.label} (all fields present, no enrichment needed)", 'info')
-            return entry_text
+            return entry_text, None
 
         title = enrich.strip_latex(fields.get('title', ''))
         found, field_sources = enrich.gather_enrichment(
@@ -697,7 +710,7 @@ commentary."""
         )
         if not found:
             self._log(f"   ⚠️  Missing fields not found via CrossRef/Scholar: {', '.join(required + desired)}", 'warning')
-            return entry_text
+            return entry_text, None
 
         by_source = {}
         for field, source in field_sources.items():
@@ -716,22 +729,22 @@ commentary."""
             merged = self.clean_bibtex(response_text(message))
             valid, _ = self.validate_braces(merged)
             if not valid:
-                return entry_text
+                return entry_text, None
         except Exception as e:
             self._log(f"   ⚠️  Enrichment merge failed: {e}", 'warning')
-            return entry_text
+            return entry_text, None
 
-        # Record per-field provenance as a persistent comment so it survives
-        # past this run's log, rather than only being visible in the console/window.
+        # Per-field provenance, returned so save_entry can persist it as a
+        # comment - it should survive past this run's log rather than being
+        # visible only in the console/window.
         source_fields = sorted(f for f, v in fields.items() if v)
         source_lines = []
         if source_fields:
             source_lines.append(f"{content.label}: {', '.join(source_fields)}")
         for src, fs in by_source.items():
             source_lines.append(f"{src}: {', '.join(sorted(fs))}")
-        comment = f"% Sources -- {'; '.join(source_lines)}\n"
 
-        return comment + merged
+        return merged, '; '.join(source_lines)
 
     def _build_audit_prompt(self, entry, content):
         """Build a prompt asking Claude to self-audit which of its own field
@@ -1223,69 +1236,30 @@ end tell'''
             f.write("\n\n")
         self._log(f"   ✗ Failed entry saved to {failed_path}", 'error')
 
-    def save_entry(self, bibtex_entry, pdf_path):
-        """Validate, enrich with a BibDesk bookmark, and append to the main bib file."""
+    def save_entry(self, result, pdf_path):
+        """Validate, enrich with a BibDesk bookmark, and append to the main bib file.
+
+        `result` is the ExtractionResult extract_bibtex() returned. Its review
+        state arrives as attributes; it is no longer prepended to the entry
+        text as `%` markers for this method to match positionally and slice
+        off. That protocol is what made the amber-colouring regression both
+        possible and silent - one marker's regex could never match, and
+        because re.match anchors at position 0, every matcher below it then
+        failed too, for every entry and every source type, reporting nothing.
+        See extraction_result.py and issues #17/#18.
+
+        The `%` comments still reach the saved file, rendered here from the
+        result rather than parsed out of it.
+        """
         pdf_path = Path(pdf_path)
 
-        # extract_bibtex() prepends a "% Source: ..." comment recording which
-        # kind of source (PDF/webpage) and locator produced this entry;
-        # clean_bibtex() strips anything before the first '@', so pull it out
-        # first and re-attach it once cleaning is done (outermost marker -
-        # see the prepend order in extract_bibtex).
-        #
-        # Until fixed here, this pattern's \b sat right after the literal
-        # ':' (`Source:\b`) - impossible, since neither side of that
-        # position is a word character - so it never matched anything.
-        # Because % Source: is always the outermost/first line and re.match
-        # anchors at position 0, that didn't just drop this comment: with
-        # bibtex_entry left unstripped, EVERY marker regex below it also
-        # failed to match against the unrelated text still sitting at
-        # position 0, for every entry this method ever saved - PDF or
-        # .webloc alike. needs_color could never become True by this path
-        # before this fix, so BibDesk's amber coloring (UNVERIFIED_COLOR)
-        # was inert from the day it was introduced, not merely blind to
-        # .webloc sources as the comments below (written after this fix)
-        # describe for the design going forward.
-        source_comment = ''
-        marker_match = re.match(r'(%\s*Source\b:[^\n]*\n)', bibtex_entry)
-        if marker_match:
-            source_comment = marker_match.group(1)
-            bibtex_entry = bibtex_entry[marker_match.end():]
+        needs_color = result.needs_color
+        # Outermost first: Source, then AMBER, then Sources. clean_bibtex()
+        # discards everything before the first '@', so these are attached
+        # after cleaning, not before.
+        comment_block = ''.join(line + "\n" for line in result.comment_lines())
 
-        # verify_and_flag_recollection() prepends a bare "% NEEDS_COLOR_FLAG"
-        # marker when a recollection-based field couldn't be confirmed or
-        # refuted via CrossRef/Scholar. Unlike the Sources comment below, this
-        # one is discarded (not re-attached) - it only decides whether to
-        # color the BibDesk publication, so it shouldn't persist in the .bib text.
-        needs_color = False
-        marker_match = re.match(r'(%\s*NEEDS_COLOR_FLAG\s*\n)', bibtex_entry)
-        if marker_match:
-            needs_color = True
-            bibtex_entry = bibtex_entry[marker_match.end():]
-
-        # extract_bibtex() prepends a "% AMBER: ..." comment when
-        # content.amber is set (web_source.py's plausibility check: a
-        # genuine but thin/sparse source). Unlike NEEDS_COLOR_FLAG, this one
-        # IS re-attached below: a .webloc source is never fileable (see the
-        # is_fileable_source check further down), so it never reaches
-        # BibDesk's own color, and this comment is the only place the flag
-        # survives into the saved .bib text.
-        amber_comment = ''
-        marker_match = re.match(r'(%\s*AMBER\b:[^\n]*\n)', bibtex_entry)
-        if marker_match:
-            amber_comment = marker_match.group(1)
-            bibtex_entry = bibtex_entry[marker_match.end():]
-
-        # enrich_entry() prepends a "% Sources -- ..." comment recording field
-        # provenance; clean_bibtex() strips anything before the first '@', so
-        # pull the comment out first and re-attach it once cleaning is done.
-        sources_comment = ''
-        marker_match = re.match(r'(%\s*Sources\b[^\n]*\n)', bibtex_entry)
-        if marker_match:
-            sources_comment = marker_match.group(1)
-            bibtex_entry = bibtex_entry[marker_match.end():]
-
-        entry = self.clean_bibtex(bibtex_entry)
+        entry = self.clean_bibtex(result.entry)
 
         # Reject responses that are not BibTeX entries
         if not entry.lstrip().startswith('@'):
@@ -1301,12 +1275,7 @@ end tell'''
             self.notify_failure(pdf_path.name, error_msg)
             return False
 
-        if sources_comment:
-            entry = sources_comment + entry
-        if amber_comment:
-            entry = amber_comment + entry
-        if source_comment:
-            entry = source_comment + entry
+        entry = comment_block + entry
 
         # Flag entries still missing critical fields after enrichment (does not block saving)
         entry_type = enrich.get_entry_type(entry)
@@ -1355,7 +1324,7 @@ end tell'''
         if needs_color:
             self._log("   ⚠️  Unverified field(s) or a thin source - color flag needs "
                       "autofile_bibdesk to apply"
-                      + (" (see the % AMBER comment in the saved entry)" if amber_comment else ""),
+                      + (" (see the % AMBER comment in the saved entry)" if result.amber_reason else ""),
                       'warning')
 
         output_path = Path(self.config['main_bib_file']).expanduser()
@@ -1471,15 +1440,15 @@ end tell'''
             self.notify_progress(f"[{i}/{total}] {pdf_path.name}", subtitle="Extracting bibliography")
 
             # Extract bibliography
-            bibtex_entry = self.extract_bibtex(pdf_path, batch_info=(i, total), model_override=model_for_file)
+            result = self.extract_bibtex(pdf_path, batch_info=(i, total), model_override=model_for_file)
 
-            if bibtex_entry.startswith("Error:"):
-                self._log(f"   ✗ {bibtex_entry}", 'error')
-                results['failed'].append((pdf_path.name, bibtex_entry))
+            if result.failed:
+                self._log(f"   ✗ {result.error}", 'error')
+                results['failed'].append((pdf_path.name, result.error))
                 continue
 
             # Save entry
-            saved = self.save_entry(bibtex_entry, pdf_path)
+            saved = self.save_entry(result, pdf_path)
             if not saved:
                 results['failed'].append((pdf_path.name, "save failed"))
                 continue
@@ -1669,15 +1638,15 @@ def main():
         for pdf_path in pdf_files:
             agent._log(f"\n📄 Processing: {pdf_path.name}", 'info')
 
-            bibtex_entry = agent.extract_bibtex(pdf_path)
+            result = agent.extract_bibtex(pdf_path)
 
-            if bibtex_entry.startswith("Error:"):
-                print(bibtex_entry, file=sys.stderr)
+            if result.failed:
+                print(result.error, file=sys.stderr)
                 continue
 
-            clean_entry = agent.clean_bibtex(bibtex_entry)
+            clean_entry = agent.clean_bibtex(result.entry)
             if not args.no_save:
-                saved = agent.save_entry(bibtex_entry, pdf_path)
+                saved = agent.save_entry(result, pdf_path)
                 if not saved:
                     print(f"Error: failed to save entry for {pdf_path.name}", file=sys.stderr)
                     sys.exit(1)

--- a/src/extraction_result.py
+++ b/src/extraction_result.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+What extract_bibtex() hands to save_entry(): the entry text, and the review
+state that belongs to it.
+
+Before this existed the two functions communicated through `%` comment markers
+prepended to the entry text, which save_entry() recovered by matching each one
+positionally with an anchored re.match and slicing it off. Three properties of
+that arrangement all bit within a month of each other:
+
+- Order was load-bearing and unchecked. Adding a marker meant prepending it in
+  one function and inserting its matcher at exactly the right point in the
+  other, in two places that named each other only in comments.
+- A failed match was silent, and cascaded. `% Source:` arrived with an
+  extraction regex that could never match (`Source:\\b` - no word boundary can
+  exist between ':' and a space), and because re.match anchors at 0 and that
+  marker was outermost, every matcher below it then ran against a string still
+  starting `% Source:` and failed too. BibDesk's amber colouring stopped
+  working for every entry and every source type, from 2026-07-30 until it was
+  found. Nothing anywhere reported a problem. See issues #17 and #18.
+- The carrier was lossy, and differed by branch. Under autofile_bibdesk the
+  importer re-serializes each entry and discards every `%` comment, so
+  comment-carried state survived only on the plain-text-append branch and
+  colour-carried state only on the BibDesk branch.
+
+The markers remain as an OUTPUT format - they are how provenance reaches the
+saved .bib text, and they are worth having there. They are no longer an
+interchange format between two functions.
+
+This module deliberately imports nothing beyond the standard library, so the
+evaluation harness can construct a result without pulling in the Anthropic
+client or pypdf. A stub that returns the shape the caller expects rather than
+the shape the system emits is how the last round of testing missed a live
+fault; sharing the real class is what stops that here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ExtractionResult:
+    """One source's extraction: the entry, plus what is known about it.
+
+    `error` set means extraction did not produce an entry, and `entry` is
+    meaningless. Every other field describes an entry that exists.
+    """
+
+    entry: str = ''
+
+    # Extraction failed. Carries the human-readable reason, already prefixed
+    # "Error: " so it reads the same wherever it is printed.
+    error: Optional[str] = None
+
+    # Which kind of source and which locator produced this - "PDF (paper.pdf)",
+    # "webpage (https://...)". Written to the saved text as "% Source: ...".
+    source_label: Optional[str] = None
+
+    # A field could not be confirmed or refuted against CrossRef/Scholar, or
+    # the source was thin. Becomes BibDesk's review colour; never written to
+    # the text, because the colour is where it belongs.
+    needs_color: bool = False
+
+    # web_source.py's plausibility check found the source genuine but thin or
+    # sparse. Written as "% AMBER: <reason>", which is the only carrier that
+    # survives on the plain-text-append branch, where no colour is possible.
+    amber_reason: Optional[str] = None
+
+    # Per-field provenance from enrichment - "CrossRef: volume, pages".
+    # Written as "% Sources -- ...".
+    field_sources: Optional[str] = None
+
+    @property
+    def failed(self) -> bool:
+        return self.error is not None
+
+    def comment_lines(self) -> list:
+        """The `%` comments this result contributes, outermost first.
+
+        `needs_color` is absent by design: it is state about the entry, not a
+        fact about it, and it reaches the reader as a colour. An INCOMPLETE
+        comment is not here either - that is determined at save time, from the
+        finished entry, not by extraction.
+        """
+        lines = []
+        if self.source_label:
+            lines.append(f"% Source: {self.source_label}")
+        if self.amber_reason:
+            lines.append(f"% AMBER: {self.amber_reason}")
+        if self.field_sources:
+            lines.append(f"% Sources -- {self.field_sources}")
+        return lines


### PR DESCRIPTION
## The problem, restated from the code

`extract_bibtex()` returned one string with up to four `%` markers prepended, and
`save_entry()` recovered that state by matching each one positionally with an
anchored `re.match` and slicing it off. Three properties, all of which bit within
a month of each other:

1. **Order was load-bearing and unchecked.** Adding a marker meant prepending it
   in one function and inserting its matcher at exactly the right point in the
   other — two places that named each other only in comments.
2. **A failed match was silent, and cascaded.** `% Source:` arrived with a regex
   that could never match (`Source:\b` — no word boundary can exist between `:`
   and a space). Because `re.match` anchors at 0 and that marker was outermost,
   every matcher below it then ran against a string still starting `% Source:`
   and failed too. `needs_color` was `False` for every entry and every source
   type from 2026-07-30 until it was found. Nothing anywhere reported a problem
   (#17).
3. **The carrier was lossy, and differed by branch** — comments survive only the
   plain-text append, colour only the BibDesk import — which neither function
   said.

## What changed

`extract_bibtex()` returns an **`ExtractionResult`** (`src/extraction_result.py`):
`entry`, `error`, `source_label`, `needs_color`, `amber_reason`, `field_sources`.
`save_entry()` takes it. `enrich_entry()` returns `(text, field_sources)` instead
of prepending its own comment.

The `%` comments still reach the saved file, rendered once by `comment_lines()` at
the point of writing, in the same order as before. **They remain an output format;
they are no longer an interchange format.** There is no parsing left to fail.

`ExtractionResult` lives in its own module and imports nothing outside the standard
library, so `dev/eval/test_eval.py`'s stub agent returns the *real* class rather
than a look-alike, without giving up that file's "no anthropic, no config.yaml"
independence. That is deliberate: a stub encodes the format its author expected,
not the one the system emits, which is how the AppleScript terminology collision
survived a round of testing here.

## What the tests establish

The five existing tests pass unchanged in what they assert — they always tested
what reaches the saved file and the kwargs BibDesk is called with, not the markers.
Only how each fixture is built has changed: an `ExtractionResult`, not a prefixed
string.

**But all five would keep passing if `extract_bibtex()` stopped populating a
field**, because each builds its own result. That is precisely the fault shape this
refactor exists to remove, so three tests are added (5 → 8):

| Test | What it covers |
|---|---|
| `test_extract_bibtex_to_save_entry_round_trip` | The real `extract_bibtex()`, only the API call and the source extractor stubbed, feeding straight into `save_entry()` |
| `test_field_sources_reaches_the_saved_text` | The one marker that had **no** coverage at all — and was innermost, so first to be lost when anything above it failed |
| `test_comment_lines_order_and_omission` | The rendering contract directly, including that `needs_color` contributes no comment |

**The round-trip test was verified against deliberate breakage**, in both
directions, because a test that passes against the broken code too is worth
nothing here:

| Breakage | Result |
|---|---|
| `source_label=None` in the returned result | `1/8 failed` — the round-trip test, alone |
| `amber_reason` not propagated | `1/8 failed` — the round-trip test, alone |
| neither | `8/8 passed` |

The other seven pass in both broken states. That is the gap being closed.

## What they do NOT establish

- **Nothing about BibDesk.** `_save_via_bibdesk` is replaced by a recorder in every
  test. The kwargs handed to it are asserted; whether the importer actually applies
  the review colour is not observable from a terminal, and is unchanged by this PR
  either way.
- **No live extraction was run on this branch.** The round-trip test exercises the
  wiring with a stubbed API call; it does not prove anything about extraction
  quality, and nothing here should affect it.
- `--rescore`: `50/61 (82%)`, unchanged from `dev/eval/baselines/2026-08-29.md`.
  This branch does not touch the prompt, so that is the expected result rather than
  a measurement of anything.

## Decisions

- **Comments are still attached on both save branches**, as before — including the
  BibDesk one, where the importer discards them. #18's text suggests rendering
  "only for the branch where comments survive", but that changes what is handed to
  BibDesk and to `add_bdsk_bookmark()`, and BibDesk's behaviour is not observable
  from here. The substance of the issue — the parsing, the ordering, the silent
  miss — is fully addressed without it. Worth doing separately, with the GUI in
  front of you.
- **A new module rather than putting the class in `biblio_agent.py`.**
  `test_eval.py` must be able to construct one without importing `biblio_agent`
  (and so `anthropic`). The alternative — duck-typing the stub on `.error`/`.entry`
  — recreates exactly the stub/reality gap this is meant to close.
- **A dataclass rather than a `(text, dict)` tuple.** #18 asked for "a small result
  object"; a tuple documents nothing and a fifth piece of state would go in
  unnamed.
- **`ExtractionResult` is re-exported through `biblio_agent`**, so
  `dev/test_biblio_agent_markers.py` needs no second import path.

## For the maintainer to check by hand

- **BibDesk.** Import one real entry with `autofile_bibdesk: true` and confirm the
  review colour still appears on an entry that warrants it, and the PDF still files.
  Both are asserted here only at the boundary.
- The `% Source:`, `% AMBER:` and `% Sources --` comments in a real
  `biblio-staging.bib` entry on the plain-text branch — same order, same content as
  before, but rendered by different code.
- `dev/test_setup.py` still reports `✗ files not in Project Structure:
  2026-08-29.md` on this branch. That is #21, pre-existing on `main` and fixed in
  PR #22; everything else is green.

## Verification environment

`~/.micromamba/envs/biblio-ai` (Python 3.13.11). `dev/test_biblio_agent_markers.py`
(8), `dev/eval/test_eval.py` (15), `dev/test_web_source.py` (40) all pass.

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjmVC9CiFbyxSjHeKfxZY4

---

## Merge order and conflicts

Six PRs touch overlapping documentation. Merging in this order resolves the
dependencies: **#22 → #26 → #28 → #27 → #25 → #29.**

Two files need hand-resolution whatever the order:

- **`dev/eval/sample/README.md`** — #26 and #28 both extend the same `note`
  bullet block, one adding `container_source`, the other `insufficient_source`.
  A certain conflict; both blocks are wanted.
- **`README.md`** — #27 rewrites the `test_biblio_agent_markers.py` paragraph;
  #28 inserts its `test_extract_pages.py` paragraph anchored on that paragraph's
  old first line.

One genuine dependency: **#28's `sample/README.md` says `select_sample.py`
preserves hand-added manifest keys across a regeneration. That code is only in
#26.** Until #26 lands, the sentence is false and a rerun of `select_sample.py`
would silently drop both `container_source` and `insufficient_source`.

---

# Measured: full 61-entry run of the merged state

The maintainer authorized one full run. It was spent on `integration-2026-08-29` —
all six PRs merged, in the order above, two documentation conflicts resolved by
hand — because that is the state `main` will actually have, and because one run of
the merge answers questions no single branch could. Full record:
[`dev/eval/baselines/2026-08-29-integration.md`](dev/eval/baselines/2026-08-29-integration.md).

**Entry type 50/61 → 51/61.** **Field verdicts: exact 249 → 240, different 117 →
117, missing 94 → 103, spurious 83 → 67** — sixteen fields the pipeline used to
invent it no longer invents, nine it used to get right it now omits, and nothing
moved into `different`.

**This is the live validation the branch did not have.** The refactor ran end to
end over **61 real sources**, with enrichment, the grounding audit and
reconciliation all making real API calls through the new `ExtractionResult` path.
**61 of 61 entries produced; no extraction failure, no unparseable entry.** The
`% Source:`, `% AMBER:` and `% Sources --` comments were rendered from the result
object throughout.

Still not established, and unchanged: BibDesk. `run_pipeline()` never calls
`save_entry()`, so the import path and the review colour remain unobserved.

---

## Correction to the field figures above

`expected.bib` changed twice on 2026-08-29 — `4dff992` (Menke2004's author) and
`7155812` (Arndt2014's title, Cavell1969a's pages) — and the field table published
in `2026-08-29.md` predates both. Comparing this run against that table would have
been comparing two ground truths.

Re-scored the baseline run's own saved output against `expected.bib` as it now
stands, so both sides face one ground truth. **The delta is unchanged:
exact 249 → 240, different 117 → 117, missing 94 → 103, spurious 83 → 67.** The
totals coincide with the published ones by accident — `author` moves 33 → 34 and
`title` 37 → 36 under the corrected file, and they offset.

Two issues this session filed are now closed as **resolved by the maintainer's
correction**, not as mistaken: #24 (real, and fixed in `7155812` mid-session — I
later checked an already-fixed file and wrongly retracted it) and #20 (real, though
the value I proposed, `180-212`, was wrong; it is `180-201`).
