### PR TITLE
Flag a PDF whose extraction finished having produced almost nothing

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ fallback and plausibility check (including the amber-vs-fail split) against cann
 fixtures - the live failures it guards against (an actual bot challenge, a half-loaded
 tab) can't be staged by hand.
 
+`python3 dev/test_extract_pages.py` self-tests the thin-yield check - the amber
+flag a PDF gets when extraction finishes having produced almost nothing. It runs
+against canned page text rather than a fixture PDF, so the word counts are exact
+and no OCR is invoked.
+
 `python3 dev/test_biblio_agent_markers.py` self-tests `save_entry()`'s marker
 extraction/reattachment - in particular that the `% AMBER: ...` comment a thin/sparse
 `.webloc` source needs (see above) actually survives into the saved `.bib` text.
@@ -122,6 +127,7 @@ absent from disk is an error at startup, not a warning.
 | `enrich_missing_fields` | `true`              | The CrossRef/Scholar lookups, the grounding audit and reconciliation. `false` leaves only the initial extraction. |
 | `verbose`               | `true`              | Progress on stderr.                                                                                               |
 | `ocr_threshold`         | `100`               | Words below which a PDF is treated as scanned.                                                                    |
+| `thin_yield_threshold`  | `400`               | Words a PDF must yield in total, after OCR, before its extraction is trusted. Below it the entry is marked amber. `0` disables. |
 | `ocr_timeout`           | `180`               | Seconds allowed to `ocrmypdf`.                                                                                    |
 | `default_ocr_language`  | `eng`               | Tesseract language used when `interactive_ocr` is `false`.                                                        |
 | `interactive_ocr`       | `true`              | `false`: never show the OCR-language dropdown, always use `default_ocr_language`. Independent of `verbose`.       |
@@ -333,7 +339,7 @@ ostracon-ai/
 ├── requirements.txt
 ├── src/
 │   ├── biblio_agent.py     # Orchestrator; run this
-│   ├── extract_pages.py    # PDF text and OCR
+│   ├── extract_pages.py    # PDF text, OCR, and the thin-yield check
 │   ├── web_source.py       # .webloc page fetching
 │   ├── enrich.py           # CrossRef/Scholar lookups and reconciliation
 │   └── progress_window.py  # The floating window

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -30,6 +30,14 @@ example_files:
 # Processing options
 ocr_threshold: 100 # Minimum words extracted before OCR is attempted on key pages
 ocr_timeout: 180 # Seconds to allow ocrmypdf on the extracted page subset before giving up
+
+# Words a PDF must yield across all its pages - after OCR, where OCR ran -
+# before its extraction is taken at face value. Below this the entry is marked
+# amber for review, exactly as a thin webpage is: it is still produced, because
+# some sources genuinely carry no bibliographic text, but it stops looking as
+# confident as an entry drawn from a full title page. Must sit above
+# ocr_threshold, or it could never fire. Set to 0 to disable.
+thin_yield_threshold: 400
 max_tokens: 4000 # Maximum tokens for Claude response
 model: "claude-sonnet-4-20250514" # Claude model to use
 

--- a/dev/eval/README.md
+++ b/dev/eval/README.md
@@ -117,6 +117,31 @@ is one chapter of it) and `insufficient_source` (the right file, yielding almost
 no text). Neither is consumed by the scorer yet: they are read by whoever reads
 a report. See [`sample/README.md`](sample/README.md).
 
+**Nor can it tell a field read from the source apart from one the model
+recalled.** Both score `exact`. The harness compares strings; it has no view of
+where a value came from, so a correct guess and a correct reading are worth the
+same to it.
+
+Gollin2011a is the worked example. Its source is three pages of glossary text,
+and of the six values in the ground-truth entry, **five appear nowhere in the
+PDF** - not `Oxford Handbook`, not `Neo-Riemannian`, not `Oxford University
+Press`, not `Oxford`, not `2011`, not `579`. Only the page-3 running header
+(`GLOSSARY 581`) is actually in the file. The 2026-08-29 baseline scored this
+entry as correct; it was correct by recollection.
+
+So **a fall in `exact` is not necessarily a regression.** A change that stops
+the model supplying values the source does not contain will score as a loss on
+every entry whose ground truth was only ever reachable by supplying them. This
+bears directly on how the `exact 249 -> 240` in
+[`baselines/2026-08-29-integration.md`](baselines/2026-08-29-integration.md) is
+read: part of that -9 is the pipeline declining to guess, and the table cannot
+say which part. Read `spurious` and `missing` alongside it, and read the entries
+themselves before calling any of it a regression.
+
+The grounding audit (`verify_and_flag_recollection()`) is the mechanism that
+does know the difference, and its verdict reaches BibDesk as a colour rather
+than the report - which is the previous point again, from the other side.
+
 ## Corrections
 
 `expected.bib` is edited by the maintainer only. It is the one file here

--- a/dev/eval/README.md
+++ b/dev/eval/README.md
@@ -96,6 +96,27 @@ is. Field counts run across every scored entry regardless of its type
 verdict - "ninety per cent correct" hides whether the tenth is a page range
 or an author, which is exactly what this table is for.
 
+## What this harness cannot measure
+
+It scores fields against ground truth. **Confidence is not a field.** An entry
+can score fully correct while carrying a review flag it should not, or missing
+one it should, and nothing here will notice either way.
+
+That is not hypothetical: BibDesk's amber colouring was inert for every entry
+and every source type from 2026-07-30 until 2026-08-29, and no run of this
+harness was capable of reporting it (Issue
+[#17](https://github.com/yrammos/biblatex-chicago-claude/issues/17)). A change
+to the flagging mechanism therefore needs its own tests -
+`dev/test_biblio_agent_markers.py` and `dev/test_extract_pages.py` - and, where
+BibDesk itself is involved, an import done by hand. A green report here is
+silent on all of it.
+
+Two manifest keys mark sample entries no extraction can score at all, for two
+different reasons - `container_source` (the file is the whole volume, the entry
+is one chapter of it) and `insufficient_source` (the right file, yielding almost
+no text). Neither is consumed by the scorer yet: they are read by whoever reads
+a report. See [`sample/README.md`](sample/README.md).
+
 ## Corrections
 
 `expected.bib` is edited by the maintainer only. It is the one file here

--- a/dev/eval/sample/README.md
+++ b/dev/eval/sample/README.md
@@ -40,6 +40,30 @@ A JSON array of objects:
 - `note` (optional) - why this source is in the sample; useful once the
   sample is large enough that the stratification isn't obvious from the
   file list alone.
+- `insufficient_source` (optional) - a sentence saying that the attached file,
+  though the right one, yields too little text to build the entry from, and
+  the figures. Present on one source so far. See below.
+
+## `insufficient_source`: the right file, and nothing in it
+
+`Motte2004` yields **232 words** across every page, after OCR, where comparable
+sources in this sample yield 1,000-3,100. The pages carry no bibliographic data
+at all - a person reading them would fail too - and the expected entry was
+written from the physical volume. No extraction can score it right.
+
+The pipeline nonetheless produced a correctly typed entry from it in the
+2026-08-29 baseline, indistinguishable in confidence from one built off a full
+title page. That is the failure this marks, and it is the same shape as a
+bot-challenge page answering HTTP 200: the process succeeded and the content
+did not.
+
+Distinct from `container_source`, which is the *wrong granularity* rather than
+too little text - there the file is a whole volume and the entry is one chapter
+of it. Both are entries no extraction can score, for different reasons, and the
+names are kept apart so a report can say which.
+
+Nothing consumes either key yet. `dev/eval/select_sample.py` carries them, and
+any other key it did not itself generate, across a regeneration of the manifest.
 
 ## Composition
 

--- a/dev/eval/sample/manifest.json
+++ b/dev/eval/sample/manifest.json
@@ -249,7 +249,8 @@
   "citekey": "Motte2004",
   "source": "Motte2004.pdf",
   "sha256": "d83ac430e4ae241011fe32e538b216362146ec00da2ab1014c3345611ba5986b",
-  "note": "@collection — non-Latin/foreign title, series"
+  "note": "@collection — non-Latin/foreign title, series",
+  "insufficient_source": "232 words across every page after OCR, against 1,000-3,100 for comparable sources; the pages carry no bibliographic data. The expected entry was written from the physical volume, so no extraction can score it."
  },
  {
   "citekey": "Neumeyer2009a",

--- a/dev/test_extract_pages.py
+++ b/dev/test_extract_pages.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Self-test for extract_pages.py's thin-yield check: the amber flag a PDF gets
+when extraction completes having produced almost nothing.
+
+The failure this guards against is not a crash. It is Motte2004 - 232 words
+across every page of the source, where comparable sources in the evaluation
+sample gave 1,000-3,100 - producing a correctly typed, entirely confident
+entry with no indication that the text it was built from carried no
+bibliographic data at all. OCR completing is not OCR succeeding, and a
+process that exits 0 having read nothing is indistinguishable downstream from
+one that read a title page. See issue #16.
+
+No PDF is needed and no OCR runs: extract_all_text() is replaced with canned
+page text, which is the input the check actually consumes. That keeps the
+word counts exact rather than approximately whatever a fixture happened to
+contain, and it means these tests exercise the arithmetic and the threshold
+rather than pypdf.
+
+    python3 dev/test_extract_pages.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import extract_pages  # noqa: E402
+
+
+class _Canned:
+    """Run extract_pdf()/extract_content() over canned page text, with no file
+    and no OCR, restoring the module afterwards.
+
+    min_words_threshold=0 keeps extract_content() off the OCR path entirely -
+    the question here is what happens to a yield that has already settled,
+    however it got there.
+    """
+
+    def __init__(self, page_texts):
+        self.page_texts = page_texts
+
+    def __enter__(self):
+        self._all_text = extract_pages.extract_all_text
+        self._metadata = extract_pages.extract_pdf_metadata
+        extract_pages.extract_all_text = lambda path: (self.page_texts, len(self.page_texts))
+        extract_pages.extract_pdf_metadata = lambda path: {}
+
+        def run(**opts):
+            return extract_pages.extract_pdf(
+                Path("canned.pdf"), quiet=True, min_words_threshold=0, **opts)
+        return run
+
+    def __exit__(self, *exc):
+        extract_pages.extract_all_text = self._all_text
+        extract_pages.extract_pdf_metadata = self._metadata
+        return False
+
+
+def _words(n):
+    """One page holding exactly n words."""
+    return " ".join(f"w{i}" for i in range(n))
+
+
+def test_thin_yield_is_flagged_amber():
+    with _Canned([_words(120), _words(112)]) as run:   # 232, Motte2004's figure
+        content = run(thin_yield_words=400)
+    assert content.amber is True, content
+    assert "232 words" in content.amber_reason, content.amber_reason
+    assert "400" in content.amber_reason, content.amber_reason
+    return True
+
+
+def test_ordinary_yield_is_not_flagged():
+    with _Canned([_words(900), _words(900)]) as run:
+        content = run(thin_yield_words=400)
+    assert content.amber is False, content
+    assert content.amber_reason is None, content
+    return True
+
+
+def test_threshold_boundary_is_exclusive():
+    # Exactly at the threshold is not thin; one word under is. Stated because
+    # an off-by-one here is invisible - it changes which entries get a flag,
+    # and nothing downstream would disagree with either answer.
+    with _Canned([_words(400)]) as run:
+        assert run(thin_yield_words=400).amber is False
+    with _Canned([_words(399)]) as run:
+        assert run(thin_yield_words=400).amber is True
+    return True
+
+
+def test_zero_threshold_disables_the_check():
+    with _Canned([_words(3)]) as run:
+        content = run(thin_yield_words=0)
+    assert content.amber is False, content
+    return True
+
+
+def test_default_threshold_sits_above_ocr_threshold():
+    # A floor at or below the OCR threshold could never fire: anything under
+    # that has already been through OCR by the time extract_pdf() looks.
+    assert extract_pages.DEFAULT_THIN_YIELD_WORDS > 100
+    with _Canned([_words(232)]) as run:
+        assert run().amber is True          # default applies with no argument
+    return True
+
+
+def test_extract_content_returns_the_yield_not_the_excerpt_length():
+    # The count has to be the whole PDF's, not the returned excerpt's - the
+    # excerpt is capped at min_first_words + last_words, so deriving the yield
+    # from it would report the cap for every long source.
+    # Two pages, so the excerpt is genuinely an excerpt: page 1 clears
+    # min_first_words and is taken whole, the rest is not.
+    with _Canned([_words(500), _words(4500)]):
+        text, total = extract_pages.extract_content(
+            Path("canned.pdf"), quiet=True, min_words_threshold=0)
+    assert total == 5000, total
+    # The excerpt the model actually sees begins with 500 of those 5,000 - so
+    # the count is demonstrably the PDF's, not the excerpt's. (The returned
+    # string is not simply shorter than the source: it also carries a
+    # headers/footers section that repeats page text, which is exactly why
+    # counting the returned string would be the wrong way to get this number.)
+    assert "--- BEGINNING (500 words) ---" in text, text[:80]
+    return True
+
+
+def test_extract_content_reports_zero_words_on_error():
+    real = extract_pages.extract_all_text
+    extract_pages.extract_all_text = lambda path: ("Error: File not found: x.pdf", 0)
+    try:
+        text, total = extract_pages.extract_content(Path("missing.pdf"), quiet=True)
+    finally:
+        extract_pages.extract_all_text = real
+    assert text.startswith("Error:"), text
+    assert total == 0, total
+    # And extract_pdf passes the error straight through rather than wrapping
+    # an errored extraction in a SourceContent that looks merely thin.
+    extract_pages.extract_all_text = lambda path: ("Error: File not found: x.pdf", 0)
+    try:
+        result = extract_pages.extract_pdf(Path("missing.pdf"), quiet=True)
+    finally:
+        extract_pages.extract_all_text = real
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    return True
+
+
+TESTS = [
+    test_thin_yield_is_flagged_amber,
+    test_ordinary_yield_is_not_flagged,
+    test_threshold_boundary_is_exclusive,
+    test_zero_threshold_disables_the_check,
+    test_default_threshold_sits_above_ocr_threshold,
+    test_extract_content_returns_the_yield_not_the_excerpt_length,
+    test_extract_content_reports_zero_words_on_error,
+]
+
+
+def main():
+    failures = []
+    for test in TESTS:
+        try:
+            assert test() is True
+            print(f"  ✓ {test.__name__}")
+        except Exception as e:
+            failures.append((test.__name__, e))
+            print(f"  ✗ {test.__name__}: {e}")
+
+    print()
+    if failures:
+        print(f"{len(failures)}/{len(TESTS)} test(s) failed.")
+        return 1
+    print(f"All {len(TESTS)} extract_pages self-tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import yaml
 from anthropic import Anthropic
 
+import extract_pages
 from extract_pages import extract_pdf
 import web_source
 import enrich
@@ -522,6 +523,8 @@ excerpt's text won't (e.g. an embedded Author field):
             language_prompt_fn=language_prompt_fn,
             min_words_threshold=self.config.get('ocr_threshold', 100),
             ocr_timeout=self.config.get('ocr_timeout', 180),
+            thin_yield_words=self.config.get(
+                'thin_yield_threshold', extract_pages.DEFAULT_THIN_YIELD_WORDS),
         )
 
     def extract_bibtex(self, path, batch_info=None, model_override=None):

--- a/src/extract_pages.py
+++ b/src/extract_pages.py
@@ -16,6 +16,15 @@ from typing import Optional
 from pypdf import PdfReader, PdfWriter
 
 
+# Words a whole PDF has to yield before its extraction is taken at face
+# value. Motte2004, the source that prompted this, gave 232 across all its
+# pages where comparable sources in the evaluation sample gave 1,000-3,100.
+# Deliberately well above ocr_threshold (100), which decides whether OCR is
+# attempted at all: a floor set at or below that could never fire, since
+# anything under it has already been through OCR by the time this is checked.
+DEFAULT_THIN_YIELD_WORDS = 400
+
+
 @dataclass
 class SourceContent:
     """Normalized shape produced by every source extractor (PDF, webloc, ...).
@@ -28,10 +37,13 @@ class SourceContent:
     metadata: dict = field(default_factory=dict)
     label: str = "PDF"          # human-readable source kind, used once in build_prompt
     url: Optional[str] = None   # set only when the source has a canonical access URL
-    # Set by web_source.py's plausibility check: the content genuinely came
-    # from the requested URL but is thin or sparse (missing metadata, short
-    # body) - not wrong, just worth a human glance. biblio_agent.py folds
-    # this into the existing "needs_color" (BibDesk amber) mechanism.
+    # The content is genuine but thin - not wrong, just worth a human glance.
+    # Set by web_source.py's plausibility check (a page that came from the
+    # requested URL but carries little metadata or a short body) and by
+    # extract_pdf() (a PDF that yielded very few words across all its pages,
+    # whether or not OCR ran). biblio_agent.py folds either into the existing
+    # "needs_color" (BibDesk amber) mechanism, so the two are indistinguishable
+    # downstream - which is the point: the reader's question is the same one.
     amber: bool = False
     amber_reason: Optional[str] = None
 
@@ -276,7 +288,12 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
         ocr_timeout: Seconds to allow ocrmypdf before giving up
 
     Returns:
-        str: Extracted text with section markers
+        (str, int): the extracted text with section markers, and the total
+        word count the PDF yielded across all its pages - after OCR, where OCR
+        ran. The count is returned rather than left to be re-derived from the
+        text, which is only an excerpt of it, and rather than parsed back out
+        of the "--- BEGINNING (n words) ---" headers, which would make a
+        display string load-bearing. On an error the pair is (error, 0).
     """
     pdf_path = Path(pdf_path)
 
@@ -284,7 +301,7 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
     result, num_pages = extract_all_text(pdf_path)
 
     if isinstance(result, str) and result.startswith("Error:"):
-        return result
+        return result, 0
 
     page_texts = result
     full_text = "\n\n".join(page_texts)
@@ -342,7 +359,7 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
             if not quiet:
                 print(f"✓ OCR successful ({total_words} words)", file=sys.stderr)
         else:
-            return f"Error: {ocr_result}"
+            return f"Error: {ocr_result}", 0
 
     # Determine beginning section: max(first page, min_first_words)
     first_page_text = page_texts[0] if page_texts else ""
@@ -359,7 +376,7 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
 
     # Short documents: return everything
     if total_words <= first_count + last_words:
-        return f"--- FULL TEXT ({total_words} words) ---\n{full_text.strip()}"
+        return f"--- FULL TEXT ({total_words} words) ---\n{full_text.strip()}", total_words
 
     # Extract last M words (snap to sentence)
     last_section = snap_to_sentence_end(full_text, last_words, from_end=True)
@@ -380,10 +397,10 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
         )
         output.append(headers_footers)
 
-    return "\n".join(output)
+    return "\n".join(output), total_words
 
 
-def extract_pdf(pdf_path, **opts):
+def extract_pdf(pdf_path, thin_yield_words=DEFAULT_THIN_YIELD_WORDS, **opts):
     """
     Extract a PDF's bibliographic content as a SourceContent.
 
@@ -393,13 +410,40 @@ def extract_pdf(pdf_path, **opts):
     extract_content() (min_first_words, last_words, min_words_threshold,
     quiet, language_prompt_fn, ocr_timeout).
 
+    Args:
+        thin_yield_words: Below this many words for the whole PDF, the result
+            is marked amber. 0 disables the check.
+
     Returns:
         SourceContent on success, or a string starting with "Error:" on failure.
     """
-    text = extract_content(pdf_path, **opts)
+    text, total_words = extract_content(pdf_path, **opts)
     if isinstance(text, str) and text.startswith("Error:"):
         return text
-    return SourceContent(text=text, metadata=extract_pdf_metadata(pdf_path), label="PDF")
+
+    # A PDF that completes extraction having yielded almost nothing is the
+    # same failure shape as a bot-challenge page that answers HTTP 200: the
+    # process succeeded and the content did not. OCR finishing is not OCR
+    # working - a scan whose text layer holds only whitespace comes back
+    # exit 0 with a handful of words, and the entry built from it looks
+    # exactly as confident as one built from three thousand.
+    #
+    # It rides the amber carrier a thin webpage already uses rather than
+    # introducing a signal of its own: identical treatment (BibDesk's review
+    # colour, and a "% AMBER: ..." comment where colour is impossible) for
+    # what is identically a source worth a human glance rather than a
+    # failure. Some sources genuinely carry no bibliographic text - a
+    # photocopied chapter with no title page - and those must still produce
+    # an entry.
+    amber = amber_reason = None
+    if thin_yield_words and total_words < thin_yield_words:
+        amber = True
+        amber_reason = (f"thin extraction: {total_words} words from the whole PDF "
+                        f"(under {thin_yield_words}) - the text may not carry the "
+                        f"work's bibliographic data at all")
+
+    return SourceContent(text=text, metadata=extract_pdf_metadata(pdf_path), label="PDF",
+                         amber=bool(amber), amber_reason=amber_reason)
 
 
 if __name__ == "__main__":
@@ -407,5 +451,6 @@ if __name__ == "__main__":
         print("Usage: python extract_pages.py <pdf_file>", file=sys.stderr)
         sys.exit(1)
 
-    result = extract_content(sys.argv[1])
-    print(result)
+    text, total_words = extract_content(sys.argv[1])
+    print(text)
+    print(f"\n--- TOTAL YIELD: {total_words} words ---", file=sys.stderr)


### PR DESCRIPTION
## The failure

Motte2004 yielded **232 words** across every page of its source — where comparable
sample sources yield 1,000–3,100 — and the pipeline produced a correctly typed,
entirely confident entry from it. OCR completing is not OCR succeeding: a scan
whose text layer holds only whitespace comes back exit 0 with a handful of words,
and the entry drawn from it looks exactly as confident as one drawn from a full
title page. Same shape as #11's bot-challenge DOM.

## What changed

`extract_content()` returns `(text, total_words)`; `extract_pdf()` marks the
`SourceContent` **amber** when the yield falls below `thin_yield_threshold`.

**No new signal, and no new marker.** It rides the amber carrier a thin webpage
already uses, so it reaches BibDesk's review colour and the `% AMBER: …` comment
through paths that already exist. Three consequences worth stating:

- The change is **identical whether or not #18 (PR #27) lands first** — nothing
  here depends on `ExtractionResult`, and nothing here adds a fifth positional
  marker to the protocol that PR removes. That was the reason #18 was placed above
  this issue in the triage; the ordering constraint turned out to be avoidable
  rather than merely survivable.
- Downstream the two causes are indistinguishable, which is the point: the
  reader's question — *is this entry worth a glance?* — is the same one.
- The entry is **still produced**. Some sources genuinely carry no bibliographic
  text, and Motte2004 is one; a person reading those pages would fail too.

The word count is *returned*, not re-derived. The returned text is an excerpt, and
it also carries a headers/footers section that repeats page text, so counting it
would be wrong in both directions. Parsing it back out of the
`--- BEGINNING (n words) ---` header would make a display string load-bearing,
which is the mistake #18 exists to remove.

## The threshold: 400, and why

Measured across all 61 sample PDFs (free — no OCR, no API):

| | |
|---|---|
| PDFs yielding 0 words pre-OCR (pure scans) | **14** of 61 |
| Lowest yield among the 47 with a text layer | **728** (Hultqvistnodate) |
| Median | **5,454** |
| Motte2004, post-OCR | **232** |
| Rimsky1952, post-OCR (OCR genuinely rescued it) | **1,044** |

400 sits between the one known bad yield and the lowest known good one, with no
text-layer PDF in the sample within 300 words of it. It must also exceed
`ocr_threshold` (100), or it could never fire — anything below that has already
been through OCR by the time `extract_pdf()` looks.

**What this does not establish:** post-OCR yields for the other 13 scanned
sources, which were not measured (each means running `ocrmypdf`). If one sits
between 232 and 728 it will be flagged. That would be visible in the next full run
and is the check working rather than failing — but it is an assumption, not a
measurement, and it is the number most worth revisiting.

## Tests

`dev/test_extract_pages.py`, 7 tests, no PDF and no OCR: `extract_all_text()` is
replaced with canned page text, so the counts are exact rather than whatever a
fixture happened to hold.

- fires at Motte2004's own figure (232), with the count and threshold in the reason
- does not fire on an ordinary yield
- the boundary in **both** directions — 400 is not thin, 399 is (an off-by-one here
  is invisible: it changes which entries get flagged and nothing downstream would
  disagree with either answer)
- `0` disables the check
- the packaged default applies with no argument, and exceeds `ocr_threshold`
- the count is the PDF's, not the excerpt's
- an errored extraction passes through as an error, not as a merely thin
  `SourceContent`

All existing suites pass unchanged: `test_eval.py` (15),
`test_biblio_agent_markers.py` (5), `test_web_source.py` (40).

## What is NOT established

- **That the amber flag reaches BibDesk as a colour.** That is a GUI fact,
  unobservable from a terminal, and it is exactly the thing #17 shows can be broken
  for a month without anyone noticing. **The maintainer must import one thin source
  by hand and look.**
- **That no sample entry is falsely flagged.** Only a full run would show that, and
  the 13 unmeasured post-OCR yields are the open question.
- `--rescore`: `50/61 (82%)`, unchanged. It re-scores saved output and is blind to
  this change, as it is to any extraction change.

## Proposal 2: marked, not wired

`Motte2004` is marked `insufficient_source` in `manifest.json` with its figures,
and documented in `dev/eval/sample/README.md`.

**Nothing consumes it.** Teaching `run.py`/`scorer.py` to exclude such entries from
field accuracy and score them instead on whether the pipeline declines is one
decision that must cover **both** causes — this and PR #26's `container_source`
(the right file at the wrong granularity, four entries). Making it twice, in two
PRs, is how the two drift apart. If it is wired, it must print both figures:
a scorer that silently drops entries breaks comparability with
`dev/eval/baselines/2026-08-29.md`, which every future delta is measured against.

`dev/eval/README.md` also now states plainly what the issue asked for: **this
harness cannot measure confidence metadata at all**, which is why the 2026-07-30
colouring regression was invisible to it.

## Decisions

- **`thin_yield_threshold` is a config key**, not a constant, and appears in
  `config.yaml.example` and README's table (`test_setup.py` requires both).
  `0` disables it rather than there being a separate on/off key.
- **Amber, not refusal.** #16 asks for the pipeline to "decline or flag rather than
  inventing". Flagging is the conservative half: refusing would have discarded
  Motte2004's entry, which the maintainer may well want as a stub. Refusal remains
  available on top of this.
- **`extract_content()`'s return type changed** rather than adding an out-parameter
  or a second function. It has exactly two callers (`extract_pdf` and `__main__`),
  both updated; the alternative encodes the yield in a display string.

## Ordering note for the maintainer

This PR adds `insufficient_source` to `manifest.json`. **PR #26 is what teaches
`select_sample.py` to preserve hand-added manifest keys across a regeneration.**
Until that lands, re-running `select_sample.py` would silently drop both this key
and #26's. Merging #26 first, or both together, avoids that; nothing else couples
them.

## Verification environment

`~/.micromamba/envs/biblio-ai` (Python 3.13.11). No API calls were made on this
branch.

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjmVC9CiFbyxSjHeKfxZY4

---

## Merge order and conflicts

Six PRs touch overlapping documentation. Merging in this order resolves the
dependencies: **#22 → #26 → #28 → #27 → #25 → #29.**

Two files need hand-resolution whatever the order:

- **`dev/eval/sample/README.md`** — #26 and #28 both extend the same `note`
  bullet block, one adding `container_source`, the other `insufficient_source`.
  A certain conflict; both blocks are wanted.
- **`README.md`** — #27 rewrites the `test_biblio_agent_markers.py` paragraph;
  #28 inserts its `test_extract_pages.py` paragraph anchored on that paragraph's
  old first line.

One genuine dependency: **#28's `sample/README.md` says `select_sample.py`
preserves hand-added manifest keys across a regeneration. That code is only in
#26.** Until #26 lands, the sentence is false and a rerun of `select_sample.py`
would silently drop both `container_source` and `insufficient_source`.

---

# Measured: full 61-entry run of the merged state

The maintainer authorized one full run. It was spent on `integration-2026-08-29` —
all six PRs merged, in the order above, two documentation conflicts resolved by
hand — because that is the state `main` will actually have, and because one run of
the merge answers questions no single branch could. Full record:
[`dev/eval/baselines/2026-08-29-integration.md`](dev/eval/baselines/2026-08-29-integration.md).

**Entry type 50/61 → 51/61.** **Field verdicts: exact 249 → 240, different 117 →
117, missing 94 → 103, spurious 83 → 67** — sixteen fields the pipeline used to
invent it no longer invents, nine it used to get right it now omits, and nothing
moved into `different`.

**The open assumption is closed.** The thin-yield floor fired **exactly once**
across 61 sources — on Motte2004, the 232-word source it was written for:

```
⚠️  Thin/sparse source (thin extraction: 232 words from the whole PDF (under 400)
    - the text may not carry the work's bibliographic data at all) - flagging for review
```

**Zero false positives.** The thirteen scanned sources whose post-OCR yield had
never been measured — named in this PR as the number most worth revisiting — all
clear 400. The threshold needs no adjustment on this evidence.

---

## Correction to the field figures above

`expected.bib` changed twice on 2026-08-29 — `4dff992` (Menke2004's author) and
`7155812` (Arndt2014's title, Cavell1969a's pages) — and the field table published
in `2026-08-29.md` predates both. Comparing this run against that table would have
been comparing two ground truths.

Re-scored the baseline run's own saved output against `expected.bib` as it now
stands, so both sides face one ground truth. **The delta is unchanged:
exact 249 → 240, different 117 → 117, missing 94 → 103, spurious 83 → 67.** The
totals coincide with the published ones by accident — `author` moves 33 → 34 and
`title` 37 → 36 under the corrected file, and they offset.

Two issues this session filed are now closed as **resolved by the maintainer's
correction**, not as mistaken: #24 (real, and fixed in `7155812` mid-session — I
later checked an already-fixed file and wrongly retracted it) and #20 (real, though
the value I proposed, `180-212`, was wrong; it is `180-201`).
