### PR TITLE
Correct two things the extraction prompt says untruthfully about itself

### DIFF
--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -304,7 +304,7 @@ class BiblioAgent:
                 "fields to omit, when Url/Urldate may appear, title case, name format, "
                 "Title/Subtitle splitting. On a style question the guidelines win; on a "
                 "what-does-the-package-support question the corpora win.\n\n"
-                "<reference_template> covers only 20 of the ~40 entry types and is NOT an "
+                "<reference_template> covers 12 of the ~40 entry types and is NOT an "
                 "allowlist: choose whichever type genuinely fits, including ones it omits "
                 "(@Letter, @CustomC, @Audio, @Artwork, @Manual, @Booklet, @Bookinbook, "
                 "@Dataset, @Standard, @Performance, @Patent, @Image, the @Mv* types, and "
@@ -432,10 +432,10 @@ excerpt's text won't (e.g. an embedded Author field):
    @Inproceedings vs @Incollection above - a named conference/proceedings
    title, not just an edited-volume structure).
    For unpublished academic work, distinguish @Thesis (a dissertation
-   submitted to a degree-granting institution - Type = {\bibstring{phdthesis}}
-   or {\bibstring{mastersthesis}}, Institution = the institution), @Report (an
+   submitted to a degree-granting institution - Type = {\\bibstring{phdthesis}}
+   or {\\bibstring{mastersthesis}}, Institution = the institution), @Report (an
    institutional/technical/research report NOT submitted for a degree - Type
-   = {\bibstring{techreport}} or a similarly descriptive bibstring), and
+   = {\\bibstring{techreport}} or a similarly descriptive bibstring), and
    @Unpublished (anything else unpublished, including a conference paper with
    no proceedings volume - see the guidelines for the required Note field).
    For a review of another work (rather than a standalone article), use


### PR DESCRIPTION
Two things `src/biblio_agent.py`'s prompt says untruthfully about itself. Both are
provable by rendering the literal rather than by running anything; neither depends
on the other.

## 1. `\bibstring` reached the model as `\x08ibstring`, three times (#23)

The instruction list is built with `prompt += """Please:` — a **plain**, not an
f-, string — so Python reads `\b` as the backspace escape. Rendering the literal
and scanning for control characters:

```
plain-string block, 7576 chars, control chars: ['0x8']
  ... 'institution - Type = {\x08ibstring{phdthesis}'
  ... '{\x08ibstring{phdthesis}}\n   or {\x08ibstring{mastersthe'
  ... 'NOT submitted for a degree - Type\n   = {\x08ibstring{techreport'
```

The one place the prompt says what a thesis or report's `Type` field should hold
said `\x08ibstring{phdthesis}`. Written `\\bibstring` now; the render is clean of
control characters afterwards, which is the check.

**Latent, not measured.** The sample's four `@Thesis`/`@Report` entries (Byom2023,
Krebs1980, Vishio2008, Wristen1998) all scored `type` `exact` in the 2026-08-29
baseline — `5 0 0 0` — which suggests the model recovered the intended form
regardless. Corrected on its own terms rather than on demonstrated harm, and **no
live run was made**: proving it either way needs a full 61-entry run.

## 2. The template's coverage was overstated by eight types (#19)

`_static_context_block()` told the model `<reference_template> covers only 20 of
the ~40 entry types`. Counted off the file the block actually loads:

```
entries: 13   distinct types: 12
article book inbook inreference misc music online periodical
reference suppbook suppcollection video
```

Now `12`.

## Decisions

- **These two travel together** rather than in separate PRs: both are one-line
  corrections to the same file's prompt text, both are "the prompt describes
  itself wrongly", and neither can be measured. Splitting them would double the
  review for no gain.
- **Kept off `issue-15-review-shorttitle`**, deliberately, so that branch's two
  live runs had one cause. Its new review guidance was written `\\bibstring` from
  the start, which is how the escaping defect was noticed.
- **The cached prefix changes.** Item 2 sits in `_static_context_block()`, so the
  next run after merge pays one cache write (≈$0.14 at the 1-hour TTL). Nothing
  else in the prefix moves. Item 1 is in the dynamic part and costs nothing.

## Out of bounds, reported not edited

CLAUDE.md carries the same overstatement in a different form — "`biblio-template.bib`
covers 13 entry types", counting entries rather than types — and is part of the
cached prefix, so an unattended session must not touch it. Filed under #19, which
also carries the larger half: `biblio-template.bib` has no `@Review` entry at all,
while the prompt cites `Dunsby1997` as its worked example.

## `--rescore`

`50/61 (82%)`, identical to `dev/eval/baselines/2026-08-29.md`. Included because
CLAUDE.md asks for it after any extraction change, but it re-scores the baseline's
*saved output* and is arithmetically incapable of reflecting a prompt edit. It
confirms the harness and ground truth are unchanged, and nothing more. Nothing here
was measured live.

## Verification environment

`~/.micromamba/envs/biblio-ai` (Python 3.13.11). `dev/eval/test_eval.py` (15),
`dev/test_biblio_agent_markers.py` (5), `dev/test_web_source.py` (40) and
`dev/test_setup.py` all pass. No API calls.

Closes #23
Refs #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjmVC9CiFbyxSjHeKfxZY4

---

## Merge order and conflicts

Six PRs touch overlapping documentation. Merging in this order resolves the
dependencies: **#22 → #26 → #28 → #27 → #25 → #29.**

Two files need hand-resolution whatever the order:

- **`dev/eval/sample/README.md`** — #26 and #28 both extend the same `note`
  bullet block, one adding `container_source`, the other `insufficient_source`.
  A certain conflict; both blocks are wanted.
- **`README.md`** — #27 rewrites the `test_biblio_agent_markers.py` paragraph;
  #28 inserts its `test_extract_pages.py` paragraph anchored on that paragraph's
  old first line.

One genuine dependency: **#28's `sample/README.md` says `select_sample.py`
preserves hand-added manifest keys across a regeneration. That code is only in
#26.** Until #26 lands, the sentence is false and a rerun of `select_sample.py`
would silently drop both `container_source` and `insufficient_source`.

---

# Measured: full 61-entry run of the merged state

The maintainer authorized one full run. It was spent on `integration-2026-08-29` —
all six PRs merged, in the order above, two documentation conflicts resolved by
hand — because that is the state `main` will actually have, and because one run of
the merge answers questions no single branch could. Full record:
[`dev/eval/baselines/2026-08-29-integration.md`](dev/eval/baselines/2026-08-29-integration.md).

**Entry type 50/61 → 51/61.** **Field verdicts: exact 249 → 240, different 117 →
117, missing 94 → 103, spurious 83 → 67** — sixteen fields the pipeline used to
invent it no longer invents, nine it used to get right it now omits, and nothing
moved into `different`.

**Ran clean; one value to check.** No control characters reached the model, and the
four `@Thesis`/`@Report` entries kept their correct types.

Byom2023's `type` went `White Paper` → `white paper`, losing an `exact`. Byom2023 is
the sample's `@Report`, and this PR is what repaired the `\bibstring{techreport}`
guidance it reads. A lowercase descriptive term is what a bibstring looks like, so
the repair plausibly pulled the value toward that form. Whether `expected.bib`'s
`White Paper` or the lowercase form is right by biblatex-chicago is a tier-1
question I did not settle — it needs the manual, or a compile.

---

## Correction to the field figures above

`expected.bib` changed twice on 2026-08-29 — `4dff992` (Menke2004's author) and
`7155812` (Arndt2014's title, Cavell1969a's pages) — and the field table published
in `2026-08-29.md` predates both. Comparing this run against that table would have
been comparing two ground truths.

Re-scored the baseline run's own saved output against `expected.bib` as it now
stands, so both sides face one ground truth. **The delta is unchanged:
exact 249 → 240, different 117 → 117, missing 94 → 103, spurious 83 → 67.** The
totals coincide with the published ones by accident — `author` moves 33 → 34 and
`title` 37 → 36 under the corrected file, and they offset.

Two issues this session filed are now closed as **resolved by the maintainer's
correction**, not as mistaken: #24 (real, and fixed in `7155812` mid-session — I
later checked an already-fixed file and wrongly retracted it) and #20 (real, though
the value I proposed, `180-212`, was wrong; it is `180-201`).
