### PR TITLE
Integration of PRs #22/#25/#26/#27/#28/#29, with the full-run record

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,11 @@ fallback and plausibility check (including the amber-vs-fail split) against cann
 fixtures - the live failures it guards against (an actual bot challenge, a half-loaded
 tab) can't be staged by hand.
 
+`python3 dev/test_extract_pages.py` self-tests the thin-yield check - the amber
+flag a PDF gets when extraction finishes having produced almost nothing. It runs
+against canned page text rather than a fixture PDF, so the word counts are exact
+and no OCR is invoked.
+
 `python3 dev/test_biblio_agent_markers.py` self-tests `save_entry()`'s marker
 extraction/reattachment - in particular that the `% AMBER: ...` comment a thin/sparse
 `.webloc` source needs (see above) actually survives into the saved `.bib` text.
@@ -122,6 +127,7 @@ absent from disk is an error at startup, not a warning.
 | `enrich_missing_fields` | `true`              | The CrossRef/Scholar lookups, the grounding audit and reconciliation. `false` leaves only the initial extraction. |
 | `verbose`               | `true`              | Progress on stderr.                                                                                               |
 | `ocr_threshold`         | `100`               | Words below which a PDF is treated as scanned.                                                                    |
+| `thin_yield_threshold`  | `400`               | Words a PDF must yield in total, after OCR, before its extraction is trusted. Below it the entry is marked amber. `0` disables. |
 | `ocr_timeout`           | `180`               | Seconds allowed to `ocrmypdf`.                                                                                    |
 | `default_ocr_language`  | `eng`               | Tesseract language used when `interactive_ocr` is `false`.                                                        |
 | `interactive_ocr`       | `true`              | `false`: never show the OCR-language dropdown, always use `default_ocr_language`. Independent of `verbose`.       |
@@ -333,7 +339,7 @@ ostracon-ai/
 ├── requirements.txt
 ├── src/
 │   ├── biblio_agent.py     # Orchestrator; run this
-│   ├── extract_pages.py    # PDF text and OCR
+│   ├── extract_pages.py    # PDF text, OCR, and the thin-yield check
 │   ├── web_source.py       # .webloc page fetching
 │   ├── enrich.py           # CrossRef/Scholar lookups and reconciliation
 │   └── progress_window.py  # The floating window

--- a/README.md
+++ b/README.md
@@ -95,9 +95,15 @@ fallback and plausibility check (including the amber-vs-fail split) against cann
 fixtures - the live failures it guards against (an actual bot challenge, a half-loaded
 tab) can't be staged by hand.
 
-`python3 dev/test_biblio_agent_markers.py` self-tests `save_entry()`'s marker
-extraction/reattachment - in particular that the `% AMBER: ...` comment a thin/sparse
-`.webloc` source needs (see above) actually survives into the saved `.bib` text.
+`python3 dev/test_biblio_agent_markers.py` self-tests what `save_entry()` writes -
+in particular that the `% AMBER: ...` comment a thin/sparse `.webloc` source needs
+(see above) actually survives into the saved `.bib` text, and that the review colour
+reaches BibDesk on the other branch. It also runs `extract_bibtex()` end to end, with
+only the API call stubbed, so a state the extractor stops populating fails a test
+rather than passing quietly: the review state travels from one to the other as an
+`ExtractionResult` (`src/extraction_result.py`), and the `%` comments are rendered at
+the point of writing. They were formerly prepended to the entry text and parsed back
+out positionally, which is how the amber colouring failed silently for a month.
 
 ## Configuration
 
@@ -333,6 +339,7 @@ ostracon-ai/
 ├── requirements.txt
 ├── src/
 │   ├── biblio_agent.py     # Orchestrator; run this
+│   ├── extraction_result.py # What extract_bibtex() hands save_entry()
 │   ├── extract_pages.py    # PDF text and OCR
 │   ├── web_source.py       # .webloc page fetching
 │   ├── enrich.py           # CrossRef/Scholar lookups and reconciliation

--- a/README.md
+++ b/README.md
@@ -351,6 +351,7 @@ ostracon-ai/
 │       ├── select_sample.py      # Builds sample/ and expected.bib from biblio.bib
 │       ├── populate_sample.py    # BibDesk attachment resolver select_sample.py imports
 │       ├── expected.bib          # Ground-truth entries; empty until populated
+│       ├── baselines/            # One dated report per full run; the comparison point
 │       └── sample/
 │           ├── manifest.json     # citekey/source/hash list; empty until populated
 │           └── selection.json    # Provenance of the last select_sample.py run

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -30,6 +30,14 @@ example_files:
 # Processing options
 ocr_threshold: 100 # Minimum words extracted before OCR is attempted on key pages
 ocr_timeout: 180 # Seconds to allow ocrmypdf on the extracted page subset before giving up
+
+# Words a PDF must yield across all its pages - after OCR, where OCR ran -
+# before its extraction is taken at face value. Below this the entry is marked
+# amber for review, exactly as a thin webpage is: it is still produced, because
+# some sources genuinely carry no bibliographic text, but it stops looking as
+# confident as an entry drawn from a full title page. Must sit above
+# ocr_threshold, or it could never fire. Set to 0 to disable.
+thin_yield_threshold: 400
 max_tokens: 4000 # Maximum tokens for Claude response
 model: "claude-sonnet-4-20250514" # Claude model to use
 

--- a/dev/eval/README.md
+++ b/dev/eval/README.md
@@ -96,6 +96,27 @@ is. Field counts run across every scored entry regardless of its type
 verdict - "ninety per cent correct" hides whether the tenth is a page range
 or an author, which is exactly what this table is for.
 
+## What this harness cannot measure
+
+It scores fields against ground truth. **Confidence is not a field.** An entry
+can score fully correct while carrying a review flag it should not, or missing
+one it should, and nothing here will notice either way.
+
+That is not hypothetical: BibDesk's amber colouring was inert for every entry
+and every source type from 2026-07-30 until 2026-08-29, and no run of this
+harness was capable of reporting it (Issue
+[#17](https://github.com/yrammos/biblatex-chicago-claude/issues/17)). A change
+to the flagging mechanism therefore needs its own tests -
+`dev/test_biblio_agent_markers.py` and `dev/test_extract_pages.py` - and, where
+BibDesk itself is involved, an import done by hand. A green report here is
+silent on all of it.
+
+Two manifest keys mark sample entries no extraction can score at all, for two
+different reasons - `container_source` (the file is the whole volume, the entry
+is one chapter of it) and `insufficient_source` (the right file, yielding almost
+no text). Neither is consumed by the scorer yet: they are read by whoever reads
+a report. See [`sample/README.md`](sample/README.md).
+
 ## Corrections
 
 `expected.bib` is edited by the maintainer only. It is the one file here

--- a/dev/eval/baselines/2026-08-29-integration.md
+++ b/dev/eval/baselines/2026-08-29-integration.md
@@ -1,0 +1,154 @@
+# Run — 2026-08-29, integration of PRs #22/#25/#26/#27/#28/#29
+
+Not a new baseline. `2026-08-29.md` remains the reference point; this records
+one full run of the merged state of six pull requests against it, made to settle
+what the individual branches could not measure.
+
+## Provenance
+
+Same sample, same ground truth, same model as the baseline: 61 sources,
+`claude-sonnet-4-6`, no `--model` override. Run from the branch
+`integration-2026-08-29`, which merges the six PRs in the order given in their
+bodies. Produced entries written to a scratch directory, so
+`dev/eval/last-run/` still holds the baseline's own output and remains what
+`--rescore` reads.
+
+No entry was written to BibDesk or to `main_bib_file`: `run_pipeline()` calls
+`extract_bibtex()` and `clean_bibtex()` only, never `save_entry()`.
+
+## Entry type: 51/61 (84%), from 50/61 (82%)
+
+One change, in the intended direction, and it is the one the prompt could reach:
+
+| Citekey | Baseline | This run |
+|---|---|---|
+| Heidegger1993 | `inbook` → `incollection` | **correct** |
+
+Everything else on the baseline's mismatch list is unmoved, entry for entry:
+Adorno2011, Ayrey2006, Cavell1969a, Hultqvistnodate, Jeong2017, Kranenburg2008,
+Monelle2008, Roudiez1984, Schenker1994a, ScienceDirect0.
+
+Four of those (Adorno2011, Cavell1969a, Roudiez1984, Schenker1994a) are the
+`container_source` entries — the attached PDF is the whole volume and does not
+record which fragment the entry describes. No extraction can score them.
+
+## Field level: the trade this run actually made
+
+| Verdict | Baseline | This run | Delta |
+|---|---|---|---|
+| exact | 249 | 240 | **−9** |
+| different | 117 | 117 | 0 |
+| missing | 94 | 103 | **+9** |
+| spurious | 83 | 67 | **−16** |
+
+Read as one sentence: **sixteen fields the pipeline used to invent, it no longer
+invents; nine it used to get right, it now omits.** Nothing moved into
+`different`, which is the verdict that matters most — a value that is present and
+wrong.
+
+That is the trade PR #26's Booktitle rule asks for in as many words ("a field left
+empty is a gap someone can see and fill; a field filled with the wrong work reads
+as evidence and will not be questioned"), and it is the trade #16 argues for
+("getting these wrong confidently is a worse failure than getting them wrong
+loudly"). Whether nine lost `exact` is worth sixteen fewer inventions is a
+judgement about the maintainer's workflow, not a fact this harness settles. It is
+the single most important thing to look at before merging #26.
+
+The largest single component is `entrysubtype`, whose spurious count falls 7 → 1.
+
+## Fields that moved
+
+| Field | exact | spurious |
+|---|---|---|
+| entrysubtype | 1 → 1 | **7 → 1** |
+| chapter | 0 → 0 | 2 → 0 |
+| publisher | 13 → 13 | 4 → 2 |
+| shorttitle | **0 → 2** | 2 → 1 |
+| author | **33 → 34** | 2 → 1 |
+| volumes | 1 → 2 | — |
+| title | 37 → 34 | 0 → 0 |
+| date | 32 → 30 | 4 → 3 |
+| editor | 11 → 9 | 2 → 2 |
+| pages | 19 → 17 | 3 → 3 |
+| location | 16 → 15 | 4 → 3 |
+| type | 5 → 4 | — |
+| foreword, booksubtitle | 1 → 0 | — |
+
+## Attribution of the fourteen lost `exact` verdicts
+
+Attribution is per entry, against the baseline's saved output. It is not clean —
+the baseline documents a ≈1.6% type-level variance floor and an unexplained
+`author` drift between two runs of an identical pipeline — so the column below is
+a reading, not a measurement.
+
+**Plausibly caused by the omit-rather-than-invent rule (PR #26).** Fields that
+became `missing`: Greenhead2016 `pages` and `publisher`, Ericson2022 `booktitle`,
+Genosko1998 `lista`, Zemtsovsky2016 `booksubtitle`, Gollin2011a `location` and
+`publisher`. The same rule is also responsible for most of the −16 spurious.
+
+**Known-unstable entries, unchanged in kind from the baseline's own findings.**
+
+- **Gollin2011a** — the baseline names this as its one unattributable flip. Here
+  it degrades further: `title` becomes `Glossary` rather than the book's title,
+  with `date` 2017, `pages` 581. The `@Suppbook` convention (the book's title in
+  `Title`) is the thing being lost. Type still correct. **Worth a look before
+  merging #26: the editor-discriminator text sits adjacent to the `@Suppbook`
+  exception and may be diluting it.**
+- **Monelle2008** — `title` `The Musical Sublime` → `Can It Be All So
+  Simple---Remix`. The source's first page runs title, author and opening subject
+  heading together with no distinction surviving OCR. Run 1 gave the wrong
+  reading, the baseline the right one, this run the wrong one again.
+- **Motte2004** — `editor` particle order. This is the 232-word source; its
+  editor comes from enrichment, not from the page.
+- **Roudiez1984** — `date` 1984 → 2024. A `container_source` entry.
+- **Jeong2017** — `Score-Informed` → `Score-informed`, the hyphenated-compound
+  title-case slip this file's Corrections section already names as a known
+  pipeline error rather than a ground-truth one.
+
+**Possibly caused by this session's changes, and worth checking.**
+
+- **Heidegger1993 `editor`** — `Krell, David Farrell` → `Krell, David~Farrell`.
+  PR #25 added "a forename followed by an initial still takes the non-breaking
+  tie" inside the `@Review` clause; `David Farrell` is two forenames, not an
+  initial, and this is a different entry type. Reads as the instruction
+  generalising past its clause.
+- **Byom2023 `type`** — `White Paper` → `white paper`. PR #29 repaired the three
+  `\bibstring` occurrences in the `@Thesis`/`@Report` guidance, which previously
+  reached the model as `\x08ibstring`. Byom2023 is the sample's `@Report`. A
+  lowercase descriptive term is what a bibstring looks like, so the repair may be
+  pulling the value toward that form.
+- **Albright2021 `foreword`** — `Rehding, Alexander` → `yes`, with
+  `introduction` newly spurious. Not attributable to any change here; recorded
+  because CLAUDE.md's tier-1 note on `@SuppBook` says the style reads these
+  fields' *presence* and never prints the value, which makes `yes` less obviously
+  wrong than it looks.
+
+## What the run settled that the branches could not
+
+- **PR #27's refactor ran end to end over 61 real sources**, with enrichment,
+  the grounding audit and reconciliation all live. No extraction failure, no
+  unparseable entry, 61 of 61 produced. The branch itself had no live run at all.
+- **PR #28's thin-yield floor fired exactly once**, on the 232-word source, with
+  the reason naming both figures:
+
+  ```
+  ⚠️  Thin/sparse source (thin extraction: 232 words from the whole PDF
+      (under 400) - the text may not carry the work's bibliographic data
+      at all) - flagging for review
+  ```
+
+  **Zero false positives across 61 sources.** That closes the open assumption in
+  that PR: the thirteen scanned sources whose post-OCR yield had never been
+  measured all clear 400.
+- **PR #25's `by` clause held at full scale.** All seven `@Review`-typed entries
+  carry `\bibstring{by}` in `Shorttitle`, against 0 of 6 in the baseline, and
+  `shorttitle` exact goes 0 → 2. On the review subset `title` exact goes 2 → 3.
+- **PR #26's first rule works** (Heidegger1993). Its second is responsible for the
+  omission trade above. Kranenburg2008 was deliberately not attempted and did not
+  move.
+
+## What it did not settle
+
+Attribution between four simultaneous changes, on any entry not named above. A
+per-branch run would cost four times as much and, at this sample size, still could
+not separate a two-entry effect from noise.

--- a/dev/eval/baselines/2026-08-29-integration.md
+++ b/dev/eval/baselines/2026-08-29-integration.md
@@ -6,8 +6,12 @@ what the individual branches could not measure.
 
 ## Provenance
 
-Same sample, same ground truth, same model as the baseline: 61 sources,
-`claude-sonnet-4-6`, no `--model` override. Run from the branch
+Same sample and same model as the baseline: 61 sources, `claude-sonnet-4-6`, no
+`--model` override. **Not the same ground truth**: `expected.bib` was corrected in
+`7155812` (2026-08-29 21:04:11 +0200) between the baseline run and this one, and
+this branch contains that correction. Every figure below that compares the two runs
+was obtained by re-scoring both against the corrected file — see the note on the
+field table. Run from the branch
 `integration-2026-08-29`, which merges the six PRs in the order given in their
 bodies. Produced entries written to a scratch directory, so
 `dev/eval/last-run/` still holds the baseline's own output and remains what
@@ -34,12 +38,25 @@ record which fragment the entry describes. No extraction can score them.
 
 ## Field level: the trade this run actually made
 
-| Verdict | Baseline | This run | Delta |
+**These figures are like for like.** `expected.bib` changed twice on 2026-08-29
+(`4dff992`, Menke2004's author; `7155812`, Arndt2014's title and Cavell1969a's
+pages), so the field table published in `2026-08-29.md` was computed against a
+ground truth that no longer exists. The "Baseline" column below is therefore **not**
+that table: it is the baseline run's own saved output, re-scored against
+`expected.bib` as it now stands, so both columns face the same ground truth.
+
+| Verdict | Baseline (re-scored) | This run | Delta |
 |---|---|---|---|
 | exact | 249 | 240 | **−9** |
 | different | 117 | 117 | 0 |
 | missing | 94 | 103 | **+9** |
 | spurious | 83 | 67 | **−16** |
+
+The totals happen to match `2026-08-29.md`'s published figures exactly, which is a
+coincidence and not a reason to trust them: two fields moved in opposite directions.
+`author` goes 33 → 34 (Menke2004, fixed after that table was computed) and `title`
+36 ← 37 (Arndt2014, fixed by `7155812`). Anyone comparing a future run against the
+published table rather than against a re-score will be off by those two.
 
 Read as one sentence: **sixteen fields the pipeline used to invent, it no longer
 invents; nine it used to get right, it now omits.** Nothing moved into

--- a/dev/eval/run.py
+++ b/dev/eval/run.py
@@ -97,13 +97,13 @@ def run_pipeline(agent, source_path, citekey=None, save_dir=None) -> "bib_audit.
     are given - see load_last_run()/--rescore.
     """
     label = f"{citekey}: " if citekey else ""
-    bibtex_entry = agent.extract_bibtex(source_path)
-    if bibtex_entry.startswith("Error:"):
-        print(f"   ⚠️  {label}{bibtex_entry}", file=sys.stderr)
-        clean = f"% extraction failed: {bibtex_entry}\n"
+    result = agent.extract_bibtex(source_path)
+    if result.failed:
+        print(f"   ⚠️  {label}{result.error}", file=sys.stderr)
+        clean = f"% extraction failed: {result.error}\n"
         entry = None
     else:
-        clean = agent.clean_bibtex(bibtex_entry)
+        clean = agent.clean_bibtex(result.entry)
         entries, _ = bib_audit.scan(clean)
         entry = entries[0] if entries else None
         if entry is None:

--- a/dev/eval/sample/README.md
+++ b/dev/eval/sample/README.md
@@ -40,6 +40,30 @@ A JSON array of objects:
 - `note` (optional) - why this source is in the sample; useful once the
   sample is large enough that the stratification isn't obvious from the
   file list alone.
+- `insufficient_source` (optional) - a sentence saying that the attached file,
+  though the right one, yields too little text to build the entry from, and
+  the figures. Present on one source so far. See below.
+
+## `insufficient_source`: the right file, and nothing in it
+
+`Motte2004` yields **232 words** across every page, after OCR, where comparable
+sources in this sample yield 1,000-3,100. The pages carry no bibliographic data
+at all - a person reading them would fail too - and the expected entry was
+written from the physical volume. No extraction can score it right.
+
+The pipeline nonetheless produced a correctly typed entry from it in the
+2026-08-29 baseline, indistinguishable in confidence from one built off a full
+title page. That is the failure this marks, and it is the same shape as a
+bot-challenge page answering HTTP 200: the process succeeded and the content
+did not.
+
+Distinct from `container_source`, which is the *wrong granularity* rather than
+too little text - there the file is a whole volume and the entry is one chapter
+of it. Both are entries no extraction can score, for different reasons, and the
+names are kept apart so a report can say which.
+
+Nothing consumes either key yet. `dev/eval/select_sample.py` carries them, and
+any other key it did not itself generate, across a regeneration of the manifest.
 
 ## Composition
 

--- a/dev/eval/sample/README.md
+++ b/dev/eval/sample/README.md
@@ -40,6 +40,41 @@ A JSON array of objects:
 - `note` (optional) - why this source is in the sample; useful once the
   sample is large enough that the stratification isn't obvious from the
   file list alone.
+- `container_source` (optional) - a sentence saying that the attached file is
+  the whole containing volume rather than the fragment the entry describes,
+  and what the fragment is. Present on four sources so far. See below.
+
+## `container_source`: entries no extraction can score
+
+Four sample entries describe a chapter, essay or introduction whose attached
+PDF is a scan of the entire book:
+
+| Citekey | PDF pages | The entry is |
+|---|---|---|
+| Adorno2011 | 588 | chapter 28 of *Baroque Music* |
+| Roudiez1984 | 310 | a 10-page translator's introduction |
+| Cavell1969a | 197 | one essay |
+| Schenker1994a | 146 | one 8-page essay |
+
+Linking a whole-volume scan to a chapter-level entry is ordinary practice in a
+personal library, and the entries are correct. But the file does not record
+*which* chapter is meant, so no amount of reading further into it recovers the
+answer - a person handed the same PDF and nothing else would fail in the same
+way. The pipeline duly describes the container: all four came back typed
+`collection`, `book`, `book`, `book` in the 2026-08-29 baseline, and the
+correspondence with the page-count ratio is exact.
+
+The key marks them so that a reader of a report knows which failures are the
+pipeline's. Nothing consumes it yet; teaching `run.py` and `scorer.py` to
+honour it belongs with the same decision for a starved source
+([#16](https://github.com/yrammos/biblatex-chicago-claude/issues/16)), which
+proposes `insufficient_source` for a different cause - the file is the right
+one but yields almost no text. The two are kept apart deliberately.
+
+`dev/eval/select_sample.py` carries `container_source`, and any other key it
+did not itself generate, across a regeneration of this file. It computes
+`citekey`, `source`, `sha256` and `note`; everything else belongs to whoever
+wrote it.
 
 ## Composition
 

--- a/dev/eval/sample/manifest.json
+++ b/dev/eval/sample/manifest.json
@@ -249,7 +249,8 @@
   "citekey": "Motte2004",
   "source": "Motte2004.pdf",
   "sha256": "d83ac430e4ae241011fe32e538b216362146ec00da2ab1014c3345611ba5986b",
-  "note": "@collection — non-Latin/foreign title, series"
+  "note": "@collection — non-Latin/foreign title, series",
+  "insufficient_source": "232 words across every page after OCR, against 1,000-3,100 for comparable sources; the pages carry no bibliographic data. The expected entry was written from the physical volume, so no extraction can score it."
  },
  {
   "citekey": "Neumeyer2009a",

--- a/dev/eval/sample/manifest.json
+++ b/dev/eval/sample/manifest.json
@@ -9,7 +9,8 @@
   "citekey": "Adorno2011",
   "source": "Adorno2011.pdf",
   "sha256": "2acda2afa7000d78b9f9c7ed77e5eef89ad3456dc96ee8e6f0822faf938ab285",
-  "note": "@incollection — series, translated"
+  "note": "@incollection — series, translated",
+  "container_source": "588-page scan of the whole of Baroque Music; the entry is its chapter 28, and nothing in the file says which chapter is meant."
  },
  {
   "citekey": "Albright2021",
@@ -69,7 +70,8 @@
   "citekey": "Cavell1969a",
   "source": "Cavell1969a.pdf",
   "sha256": "f411abde3cdf16e47096a5a96e0c09a1cbd78d2788362d5d6764c3ea1a80153f",
-  "note": "@inbook — plain (control)"
+  "note": "@inbook — plain (control)",
+  "container_source": "197-page scan of the whole of Must We Mean What We Say?; the entry is one essay from it."
  },
  {
   "citekey": "Dhomont1996",
@@ -285,7 +287,8 @@
   "citekey": "Roudiez1984",
   "source": "Roudiez1984.pdf",
   "sha256": "74ebe3fc3b4ab1ff84266d662fbdc40989ebe59e679d8adfede8d6f644df53ff",
-  "note": "@suppbook — bookauthor, translated"
+  "note": "@suppbook — bookauthor, translated",
+  "container_source": "310-page scan of the whole of Revolution in Poetic Language; the entry is the translator's 10-page introduction."
  },
  {
   "citekey": "Schachter2000",
@@ -303,7 +306,8 @@
   "citekey": "Schenker1994a",
   "source": "Schenker1994a.pdf",
   "sha256": "3f57e3b25e57677a8699085d103805a3313de8ecaf066efaebcccb67eeaa6ca3",
-  "note": "@inbook — series"
+  "note": "@inbook — series",
+  "container_source": "146-page scan of the whole of Das Meisterwerk in der Musik I; the entry is one 8-page essay from it."
  },
  {
   "citekey": "ScienceDirect0",

--- a/dev/eval/select_sample.py
+++ b/dev/eval/select_sample.py
@@ -274,6 +274,35 @@ def select(candidates, quota, seed):
     return chosen, have, by_author
 
 
+# The keys this script computes for every manifest item. Anything else in an
+# existing manifest.json was put there by a person and is carried across a
+# rerun unchanged - see manifest_extras() and dev/eval/sample/README.md.
+GENERATED_MANIFEST_KEYS = frozenset({"citekey", "source", "sha256", "note"})
+
+
+def manifest_extras(manifest_path):
+    """citekey -> {hand-added key: value} from an existing manifest.json.
+
+    Empty for a missing, empty or malformed file: this exists to preserve
+    annotations when there are any, and must never be the reason a fresh
+    selection cannot be written.
+    """
+    try:
+        items = json.loads(Path(manifest_path).read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {}
+    if not isinstance(items, list):
+        return {}
+    extras = {}
+    for item in items:
+        if not isinstance(item, dict) or "citekey" not in item:
+            continue
+        kept = {k: v for k, v in item.items() if k not in GENERATED_MANIFEST_KEYS}
+        if kept:
+            extras[item["citekey"]] = kept
+    return extras
+
+
 # ── Main ─────────────────────────────────────────────────────────────────
 
 
@@ -383,6 +412,14 @@ def main(argv=None):
     sample_dir = Path(args.sample_dir)
     sample_dir.mkdir(parents=True, exist_ok=True)
 
+    # Keys a person added to the existing manifest by hand, so a rerun does not
+    # silently drop them. Everything this script generates is recomputed;
+    # anything else belongs to whoever wrote it. `container_source` is the case
+    # this was written for - a judgement about the source that no amount of
+    # re-selection can rederive - but the rule is deliberately about unknown
+    # keys in general, not about that one name.
+    kept = manifest_extras(sample_dir / "manifest.json")
+
     manifest, bib_out = [], []
     for c in chosen:
         dest = sample_dir / f"{c['citekey']}{c['path'].suffix.lower()}"
@@ -392,14 +429,14 @@ def main(argv=None):
             if c["feat"]
             else "plain (control)"
         )
-        manifest.append(
-            {
-                "citekey": c["citekey"],
-                "source": dest.name,
-                "sha256": hashlib.sha256(dest.read_bytes()).hexdigest(),
-                "note": note,
-            }
-        )
+        item = {
+            "citekey": c["citekey"],
+            "source": dest.name,
+            "sha256": hashlib.sha256(dest.read_bytes()).hexdigest(),
+            "note": note,
+        }
+        item.update(kept.get(c["citekey"], {}))
+        manifest.append(item)
         # Verbatim source bytes: expected.bib keeps the entry exactly as it was
         # written. Fields the pipeline never produces are excluded at scoring
         # time by scorer.py, not stripped here.

--- a/dev/eval/test_eval.py
+++ b/dev/eval/test_eval.py
@@ -28,6 +28,7 @@ import bib_audit  # noqa: E402
 import run as eval_run  # noqa: E402
 from scorer import score_entry, aggregate, format_report  # noqa: E402
 import populate_sample  # noqa: E402
+import select_sample  # noqa: E402
 
 
 def _entry(text: str) -> bib_audit.Entry:
@@ -404,6 +405,40 @@ def test_load_manifest_reads_json():
     return True
 
 
+def test_manifest_extras_keeps_only_hand_added_keys():
+    """A rerun of select_sample.py recomputes citekey/source/sha256/note and
+    must carry everything else across untouched - `container_source` is a
+    judgement about the source that re-selection cannot rederive, so losing it
+    would be silent and permanent."""
+    with tempfile.TemporaryDirectory() as td:
+        path = Path(td) / 'manifest.json'
+        path.write_text(json.dumps([
+            {"citekey": "A", "source": "A.pdf", "sha256": "deadbeef",
+             "note": "@book — plain (control)", "container_source": "whole volume"},
+            {"citekey": "B", "source": "B.pdf", "note": "@article — plain (control)"},
+        ]), encoding='utf-8')
+        extras = select_sample.manifest_extras(path)
+        # Only the hand-added key survives, and only for the item that had one.
+        assert extras == {"A": {"container_source": "whole volume"}}, extras
+    return True
+
+
+def test_manifest_extras_survives_a_manifest_it_cannot_read():
+    """Preserving annotations must never be the reason a fresh selection
+    cannot be written: absent, malformed and wrong-shaped all yield {}."""
+    with tempfile.TemporaryDirectory() as td:
+        td = Path(td)
+        assert select_sample.manifest_extras(td / 'nope.json') == {}
+        (td / 'bad.json').write_text('{not json', encoding='utf-8')
+        assert select_sample.manifest_extras(td / 'bad.json') == {}
+        (td / 'object.json').write_text('{"citekey": "A"}', encoding='utf-8')
+        assert select_sample.manifest_extras(td / 'object.json') == {}
+        (td / 'ragged.json').write_text(
+            json.dumps(["a string", {"no": "citekey", "x": 1}]), encoding='utf-8')
+        assert select_sample.manifest_extras(td / 'ragged.json') == {}
+    return True
+
+
 TESTS = [
     test_score_entry_all_verdicts,
     test_score_entry_normalizes_whitespace,
@@ -420,6 +455,8 @@ TESTS = [
     test_main_rescore_only_restricts_to_named_citekeys,
     test_load_manifest_missing_is_empty_not_error,
     test_load_manifest_reads_json,
+    test_manifest_extras_keeps_only_hand_added_keys,
+    test_manifest_extras_survives_a_manifest_it_cannot_read,
 ]
 
 

--- a/dev/eval/test_eval.py
+++ b/dev/eval/test_eval.py
@@ -28,6 +28,7 @@ import bib_audit  # noqa: E402
 import run as eval_run  # noqa: E402
 from scorer import score_entry, aggregate, format_report  # noqa: E402
 import populate_sample  # noqa: E402
+from extraction_result import ExtractionResult  # noqa: E402
 
 
 def _entry(text: str) -> bib_audit.Entry:
@@ -268,13 +269,23 @@ def test_evaluate_end_to_end():
 
 class _FakeAgent:
     """Stands in for biblio_agent.BiblioAgent's two methods run_pipeline()
-    calls - enough to test the save/reload round trip without the API."""
+    calls - enough to test the save/reload round trip without the API.
+
+    extract_bibtex() returns a real ExtractionResult, not a look-alike. A stub
+    encodes the format the author expected rather than the one the system
+    emits, which is how a live fault survived a round of testing here before;
+    importing the actual class removes the gap. extraction_result.py depends on
+    nothing outside the standard library, so this costs the file none of its
+    "no anthropic, no config.yaml" independence."""
 
     def __init__(self, bibtex_by_source):
         self._bibtex_by_source = bibtex_by_source
 
     def extract_bibtex(self, source_path):
-        return self._bibtex_by_source[source_path.name]
+        text = self._bibtex_by_source[source_path.name]
+        if text.startswith("Error:"):
+            return ExtractionResult(error=text)
+        return ExtractionResult(entry=text, source_label=f"PDF ({source_path.name})")
 
     def clean_bibtex(self, bibtex_entry):
         return bibtex_entry

--- a/dev/test_biblio_agent_markers.py
+++ b/dev/test_biblio_agent_markers.py
@@ -1,18 +1,29 @@
 #!/usr/bin/env python3
 """
-Regression test for BiblioAgent.save_entry()'s marker extraction/reattachment
-- specifically the "% AMBER: ..." comment web_source.py's content-plausibility
-follow-up relies on to survive into the saved .bib text for a .webloc source
-(never fileable, so it never reaches BibDesk's own color - see save_entry).
+Regression test for what BiblioAgent.save_entry() writes - specifically the
+"% AMBER: ..." comment web_source.py's content-plausibility follow-up relies
+on to survive into the saved .bib text for a .webloc source (never fileable,
+so it never reaches BibDesk's own color - see save_entry), and the review
+color reaching BibDesk on the other branch.
 
-Found in passing while adding that marker: the pre-existing "% Source: ..."
-regex placed its \\b word-boundary assertion right after the literal colon
-(`Source:\\b`), which can never match (a non-word character can't start a
-word boundary against another non-word character) - so source_comment was
-always empty, and clean_bibtex()'s "strip everything before the first @"
-silently discarded the "% Source: ..." comment from every saved entry. Fixed
-alongside the new "% AMBER: ..." marker, which was written with the same
-mistake and would otherwise have failed exactly the same way, invisibly.
+These tests were written against the marker protocol: save_entry() took a
+string with up to four "%" markers prepended, and recovered the state by
+matching each positionally with an anchored re.match. That protocol is gone
+(issue #18) - state now arrives as an ExtractionResult, and the comments are
+rendered at the point of writing rather than parsed out of the text. What the
+tests assert is unchanged, because they always asserted on what reaches the
+saved file and on the kwargs BibDesk is called with, not on the markers. Only
+how each fixture is built has changed: an ExtractionResult, not a prefixed
+string.
+
+The fault they were written for is worth restating, since it is what the
+refactor removes. The "% Source: ..." regex placed its \\b word-boundary
+assertion right after the literal colon (`Source:\\b`), which can never match.
+Because that marker was outermost and re.match anchors at position 0, every
+matcher below it then ran against a string still starting "% Source:" and
+failed too - so needs_color was False for every entry and every source type,
+and BibDesk's amber coloring was inert from 2026-07-30 until it was found. See
+issue #17 for the affected window.
 
 No API call, no network: uses config.yaml as-is (BiblioAgent's __init__
 constructs an Anthropic client but never calls it here), redirected to a
@@ -56,28 +67,30 @@ def _capture_bibdesk(agent):
 
 
 def test_source_and_amber_comments_survive_needs_color_flag_is_discarded():
-    entry_text = (
-        "% Source: webpage (https://example.org/x)\n"
-        "% NEEDS_COLOR_FLAG\n"
-        "% AMBER: no Author/Doi/PublicationDate - only Urldate available to date it\n"
-        "@Online{MarkerTest2026,\n"
-        "  Title = {A Study of Musical Form},\n"
-        "  Urldate = {2026-08-29},\n"
-        "}\n"
+    result = biblio_agent.ExtractionResult(
+        entry=(
+            "@Online{MarkerTest2026,\n"
+            "  Title = {A Study of Musical Form},\n"
+            "  Urldate = {2026-08-29},\n"
+            "}\n"
+        ),
+        source_label="webpage (https://example.org/x)",
+        needs_color=True,
+        amber_reason="no Author/Doi/PublicationDate - only Urldate available to date it",
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
         agent = _agent(bib_path)
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "smoketest.webloc")
+            ok = agent.save_entry(result, "smoketest.webloc")
         saved = bib_path.read_text(encoding="utf-8")
 
     assert ok is True
     # NEEDS_COLOR_FLAG is internal bookkeeping only - must not reach the file.
     assert "NEEDS_COLOR_FLAG" not in saved, saved
     # Both comments that ARE meant to persist must actually be there, in the
-    # order extract_bibtex() prepends them (Source outermost, AMBER next).
+    # order comment_lines() renders them (Source outermost, AMBER next).
     assert saved.index("% Source:") < saved.index("% AMBER:") < saved.index("@Online"), saved
     assert "% AMBER: no Author/Doi/PublicationDate" in saved, saved
     assert "@Online{MarkerTest2026," in saved, saved
@@ -91,19 +104,21 @@ def test_entry_without_amber_marker_is_unaffected():
     # A plain PDF-sourced entry (no AMBER marker at all) must still save
     # correctly and keep its Source comment - the fix must not have broken
     # the common case while fixing the broken one.
-    entry_text = (
-        "% Source: PDF (paper.pdf)\n"
-        "@Article{PlainTest2026,\n"
-        "  Title = {An Ordinary Article},\n"
-        "  Author = {Doe, Jane},\n"
-        "}\n"
+    result = biblio_agent.ExtractionResult(
+        entry=(
+            "@Article{PlainTest2026,\n"
+            "  Title = {An Ordinary Article},\n"
+            "  Author = {Doe, Jane},\n"
+            "}\n"
+        ),
+        source_label="PDF (paper.pdf)",
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
         agent = _agent(bib_path)
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "plaintest.pdf")
+            ok = agent.save_entry(result, "plaintest.pdf")
         saved = bib_path.read_text(encoding="utf-8")
 
     assert ok is True
@@ -119,11 +134,11 @@ def test_webloc_reaches_bibdesk_and_is_colored_without_auto_file():
     # the amber flag - and a .webloc entry used to be excluded from the import
     # path entirely, so it got neither. It must now be imported and colored,
     # with only `auto file` withheld (there is no document to file).
-    entry_text = (
-        "% Source: webpage (https://example.org/x)\n"
-        "% NEEDS_COLOR_FLAG\n"
-        "% AMBER: no Author/Doi/PublicationDate - only Urldate available to date it\n"
-        "@Online{WeblocTest2026,\n  Title = {A Study of Musical Form},\n}\n"
+    result = biblio_agent.ExtractionResult(
+        entry="@Online{WeblocTest2026,\n  Title = {A Study of Musical Form},\n}\n",
+        source_label="webpage (https://example.org/x)",
+        needs_color=True,
+        amber_reason="no Author/Doi/PublicationDate - only Urldate available to date it",
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
@@ -131,7 +146,7 @@ def test_webloc_reaches_bibdesk_and_is_colored_without_auto_file():
         calls = _capture_bibdesk(agent)
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "smoketest.webloc")
+            ok = agent.save_entry(result, "smoketest.webloc")
 
     assert ok is True
     assert calls, "a .webloc entry never reached _save_via_bibdesk"
@@ -146,10 +161,10 @@ def test_pdf_still_auto_files():
     # The other side of the same split: a PDF has a document, so auto_file
     # stays on. Guards against "fix the .webloc case, silently stop filing
     # every PDF."
-    entry_text = (
-        "% Source: PDF (paper.pdf)\n"
-        "% NEEDS_COLOR_FLAG\n"
-        "@Article{PdfTest2026,\n  Title = {An Ordinary Article},\n  Author = {Doe, Jane},\n}\n"
+    result = biblio_agent.ExtractionResult(
+        entry="@Article{PdfTest2026,\n  Title = {An Ordinary Article},\n  Author = {Doe, Jane},\n}\n",
+        source_label="PDF (paper.pdf)",
+        needs_color=True,
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
@@ -160,7 +175,7 @@ def test_pdf_still_auto_files():
         agent.add_bdsk_bookmark = lambda entry, path: entry
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "paper.pdf")
+            ok = agent.save_entry(result, "paper.pdf")
 
     assert ok is True
     assert calls["auto_file"] is True, calls
@@ -171,9 +186,9 @@ def test_pdf_still_auto_files():
 def test_no_color_flag_means_no_color():
     # needs_color must not become sticky: an entry carrying no
     # NEEDS_COLOR_FLAG has to reach BibDesk uncolored.
-    entry_text = (
-        "% Source: webpage (https://example.org/x)\n"
-        "@Online{CleanTest2026,\n  Title = {A Study of Musical Form},\n}\n"
+    result = biblio_agent.ExtractionResult(
+        entry="@Online{CleanTest2026,\n  Title = {A Study of Musical Form},\n}\n",
+        source_label="webpage (https://example.org/x)",
     )
     with tempfile.TemporaryDirectory() as td:
         bib_path = Path(td) / "staging.bib"
@@ -181,10 +196,126 @@ def test_no_color_flag_means_no_color():
         calls = _capture_bibdesk(agent)
         err = io.StringIO()
         with redirect_stderr(err):
-            ok = agent.save_entry(entry_text, "clean.webloc")
+            ok = agent.save_entry(result, "clean.webloc")
 
     assert ok is True
     assert calls["needs_color"] is False, calls
+    return True
+
+
+def test_field_sources_reaches_the_saved_text():
+    # enrich_entry()'s per-field provenance was the one marker with no
+    # coverage at all, and it is the marker that sat innermost - so under the
+    # old positional protocol it was the first to be lost whenever anything
+    # above it failed to match, and nothing would have said so.
+    result = biblio_agent.ExtractionResult(
+        entry="@Article{SourcesTest2026,\n  Title = {An Ordinary Article},\n  Author = {Doe, Jane},\n}\n",
+        source_label="PDF (paper.pdf)",
+        field_sources="PDF: title, author; CrossRef: volume, pages",
+    )
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        agent = _agent(bib_path)
+        err = io.StringIO()
+        with redirect_stderr(err):
+            ok = agent.save_entry(result, "paper.pdf")
+        saved = bib_path.read_text(encoding="utf-8")
+
+    assert ok is True
+    assert "% Sources -- PDF: title, author; CrossRef: volume, pages" in saved, saved
+    # Innermost of the three: after Source, immediately before the entry.
+    assert saved.index("% Source:") < saved.index("% Sources --") < saved.index("@Article"), saved
+    return True
+
+
+def test_comment_lines_order_and_omission():
+    # The rendering order is the contract the two assertions above depend on,
+    # and it is worth asserting directly rather than only through the file.
+    # needs_color must never appear: it is a colour, not a comment, and
+    # writing it was what the old NEEDS_COLOR_FLAG marker had to undo.
+    full = biblio_agent.ExtractionResult(
+        entry="@Book{X,}", source_label="PDF (a.pdf)", needs_color=True,
+        amber_reason="thin source", field_sources="CrossRef: date",
+    )
+    assert full.comment_lines() == [
+        "% Source: PDF (a.pdf)",
+        "% AMBER: thin source",
+        "% Sources -- CrossRef: date",
+    ], full.comment_lines()
+
+    # Absent state contributes no line at all - not an empty one.
+    assert biblio_agent.ExtractionResult(entry="@Book{X,}").comment_lines() == []
+    assert biblio_agent.ExtractionResult(
+        entry="@Book{X,}", needs_color=True).comment_lines() == []
+
+    # A failed result reports itself as failed and carries the reason.
+    failed = biblio_agent.ExtractionResult(error="Error: File not found: x.pdf")
+    assert failed.failed is True
+    assert biblio_agent.ExtractionResult(entry="@Book{X,}").failed is False
+    return True
+
+
+def test_extract_bibtex_to_save_entry_round_trip():
+    """The join the old protocol had no coverage of at all.
+
+    Every test above builds its own ExtractionResult, so all of them would
+    keep passing if extract_bibtex() stopped populating one - which is the
+    exact shape of the fault this refactor is for. This one runs the real
+    extract_bibtex(), with only the network stubbed, and feeds what it
+    returns straight to save_entry().
+
+    Stubbed: the Anthropic call, and a `.fake` source extractor registered in
+    EXTRACTORS so no PDF or webpage is needed. Not stubbed: prompt building,
+    forbidden-field stripping, the amber fold-in, the result construction,
+    and all of save_entry.
+    """
+    import extract_pages
+
+    class _Msg:
+        content = [type("B", (), {"type": "text",
+                                  "text": "@Online{RoundTrip2026,\n  Title = {A Study of Musical Form},\n}"})()]
+
+    class _Messages:
+        def create(self, **kwargs):
+            return _Msg()
+
+    with tempfile.TemporaryDirectory() as td:
+        bib_path = Path(td) / "staging.bib"
+        source = Path(td) / "thin.fake"
+        source.write_text("placeholder", encoding="utf-8")
+
+        agent = _agent(bib_path)
+        # No enrichment: that path makes its own network calls, and the join
+        # under test is extract_bibtex -> save_entry, not CrossRef.
+        agent.config["enrich_missing_fields"] = False
+        agent.client = type("C", (), {"messages": _Messages()})()
+
+        biblio_agent.EXTRACTORS[".fake"] = lambda path, **kw: extract_pages.SourceContent(
+            text="some body text", label="webpage", url="https://example.org/x",
+            amber=True, amber_reason="short body",
+        )
+        try:
+            err = io.StringIO()
+            with redirect_stderr(err):
+                result = agent.extract_bibtex(source)
+                ok = agent.save_entry(result, source)
+        finally:
+            del biblio_agent.EXTRACTORS[".fake"]
+
+        saved = bib_path.read_text(encoding="utf-8")
+
+    # extract_bibtex actually populated the state, rather than the test
+    # asserting a shape it invented itself.
+    assert result.failed is False, result
+    assert result.source_label == "webpage (https://example.org/x)", result
+    assert result.amber_reason == "short body", result
+    assert result.needs_color is True, result
+    # ...and every bit of it that should reach the file did.
+    assert ok is True
+    assert "% Source: webpage (https://example.org/x)" in saved, saved
+    assert "% AMBER: short body" in saved, saved
+    assert "NEEDS_COLOR_FLAG" not in saved, saved
+    assert "@Online{RoundTrip2026," in saved, saved
     return True
 
 
@@ -194,6 +325,9 @@ TESTS = [
     test_webloc_reaches_bibdesk_and_is_colored_without_auto_file,
     test_pdf_still_auto_files,
     test_no_color_flag_means_no_color,
+    test_field_sources_reaches_the_saved_text,
+    test_comment_lines_order_and_omission,
+    test_extract_bibtex_to_save_entry_round_trip,
 ]
 
 

--- a/dev/test_extract_pages.py
+++ b/dev/test_extract_pages.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Self-test for extract_pages.py's thin-yield check: the amber flag a PDF gets
+when extraction completes having produced almost nothing.
+
+The failure this guards against is not a crash. It is Motte2004 - 232 words
+across every page of the source, where comparable sources in the evaluation
+sample gave 1,000-3,100 - producing a correctly typed, entirely confident
+entry with no indication that the text it was built from carried no
+bibliographic data at all. OCR completing is not OCR succeeding, and a
+process that exits 0 having read nothing is indistinguishable downstream from
+one that read a title page. See issue #16.
+
+No PDF is needed and no OCR runs: extract_all_text() is replaced with canned
+page text, which is the input the check actually consumes. That keeps the
+word counts exact rather than approximately whatever a fixture happened to
+contain, and it means these tests exercise the arithmetic and the threshold
+rather than pypdf.
+
+    python3 dev/test_extract_pages.py
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "src"))
+
+import extract_pages  # noqa: E402
+
+
+class _Canned:
+    """Run extract_pdf()/extract_content() over canned page text, with no file
+    and no OCR, restoring the module afterwards.
+
+    min_words_threshold=0 keeps extract_content() off the OCR path entirely -
+    the question here is what happens to a yield that has already settled,
+    however it got there.
+    """
+
+    def __init__(self, page_texts):
+        self.page_texts = page_texts
+
+    def __enter__(self):
+        self._all_text = extract_pages.extract_all_text
+        self._metadata = extract_pages.extract_pdf_metadata
+        extract_pages.extract_all_text = lambda path: (self.page_texts, len(self.page_texts))
+        extract_pages.extract_pdf_metadata = lambda path: {}
+
+        def run(**opts):
+            return extract_pages.extract_pdf(
+                Path("canned.pdf"), quiet=True, min_words_threshold=0, **opts)
+        return run
+
+    def __exit__(self, *exc):
+        extract_pages.extract_all_text = self._all_text
+        extract_pages.extract_pdf_metadata = self._metadata
+        return False
+
+
+def _words(n):
+    """One page holding exactly n words."""
+    return " ".join(f"w{i}" for i in range(n))
+
+
+def test_thin_yield_is_flagged_amber():
+    with _Canned([_words(120), _words(112)]) as run:   # 232, Motte2004's figure
+        content = run(thin_yield_words=400)
+    assert content.amber is True, content
+    assert "232 words" in content.amber_reason, content.amber_reason
+    assert "400" in content.amber_reason, content.amber_reason
+    return True
+
+
+def test_ordinary_yield_is_not_flagged():
+    with _Canned([_words(900), _words(900)]) as run:
+        content = run(thin_yield_words=400)
+    assert content.amber is False, content
+    assert content.amber_reason is None, content
+    return True
+
+
+def test_threshold_boundary_is_exclusive():
+    # Exactly at the threshold is not thin; one word under is. Stated because
+    # an off-by-one here is invisible - it changes which entries get a flag,
+    # and nothing downstream would disagree with either answer.
+    with _Canned([_words(400)]) as run:
+        assert run(thin_yield_words=400).amber is False
+    with _Canned([_words(399)]) as run:
+        assert run(thin_yield_words=400).amber is True
+    return True
+
+
+def test_zero_threshold_disables_the_check():
+    with _Canned([_words(3)]) as run:
+        content = run(thin_yield_words=0)
+    assert content.amber is False, content
+    return True
+
+
+def test_default_threshold_sits_above_ocr_threshold():
+    # A floor at or below the OCR threshold could never fire: anything under
+    # that has already been through OCR by the time extract_pdf() looks.
+    assert extract_pages.DEFAULT_THIN_YIELD_WORDS > 100
+    with _Canned([_words(232)]) as run:
+        assert run().amber is True          # default applies with no argument
+    return True
+
+
+def test_extract_content_returns_the_yield_not_the_excerpt_length():
+    # The count has to be the whole PDF's, not the returned excerpt's - the
+    # excerpt is capped at min_first_words + last_words, so deriving the yield
+    # from it would report the cap for every long source.
+    # Two pages, so the excerpt is genuinely an excerpt: page 1 clears
+    # min_first_words and is taken whole, the rest is not.
+    with _Canned([_words(500), _words(4500)]):
+        text, total = extract_pages.extract_content(
+            Path("canned.pdf"), quiet=True, min_words_threshold=0)
+    assert total == 5000, total
+    # The excerpt the model actually sees begins with 500 of those 5,000 - so
+    # the count is demonstrably the PDF's, not the excerpt's. (The returned
+    # string is not simply shorter than the source: it also carries a
+    # headers/footers section that repeats page text, which is exactly why
+    # counting the returned string would be the wrong way to get this number.)
+    assert "--- BEGINNING (500 words) ---" in text, text[:80]
+    return True
+
+
+def test_extract_content_reports_zero_words_on_error():
+    real = extract_pages.extract_all_text
+    extract_pages.extract_all_text = lambda path: ("Error: File not found: x.pdf", 0)
+    try:
+        text, total = extract_pages.extract_content(Path("missing.pdf"), quiet=True)
+    finally:
+        extract_pages.extract_all_text = real
+    assert text.startswith("Error:"), text
+    assert total == 0, total
+    # And extract_pdf passes the error straight through rather than wrapping
+    # an errored extraction in a SourceContent that looks merely thin.
+    extract_pages.extract_all_text = lambda path: ("Error: File not found: x.pdf", 0)
+    try:
+        result = extract_pages.extract_pdf(Path("missing.pdf"), quiet=True)
+    finally:
+        extract_pages.extract_all_text = real
+    assert isinstance(result, str) and result.startswith("Error:"), result
+    return True
+
+
+TESTS = [
+    test_thin_yield_is_flagged_amber,
+    test_ordinary_yield_is_not_flagged,
+    test_threshold_boundary_is_exclusive,
+    test_zero_threshold_disables_the_check,
+    test_default_threshold_sits_above_ocr_threshold,
+    test_extract_content_returns_the_yield_not_the_excerpt_length,
+    test_extract_content_reports_zero_words_on_error,
+]
+
+
+def main():
+    failures = []
+    for test in TESTS:
+        try:
+            assert test() is True
+            print(f"  ✓ {test.__name__}")
+        except Exception as e:
+            failures.append((test.__name__, e))
+            print(f"  ✗ {test.__name__}: {e}")
+
+    print()
+    if failures:
+        print(f"{len(failures)}/{len(TESTS)} test(s) failed.")
+        return 1
+    print(f"All {len(TESTS)} extract_pages self-tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/dev/test_setup.py
+++ b/dev/test_setup.py
@@ -212,6 +212,16 @@ def test_documentation():
     paths = [Path(f) for f in tracked
              if Path(f).name not in boilerplate and Path(f).suffix != ".png"]
 
+    # Directories whose contents are dated run artifacts rather than code:
+    # every full evaluation run adds a `<date>.md` here, and naming each one
+    # in the tree would mean a README edit per run and a failing check for
+    # whoever forgets. Documenting the directory documents its contents - but
+    # the directory itself must still be named, so the tree cannot stay silent
+    # about it either.
+    dated_dirs = {"dev/eval/baselines"}
+    paths = [p for p in paths
+             if str(p.parent) not in dated_dirs or not _names(readme, f"{p.parent.name}/")]
+
     # The tree names files by basename under a directory node, so match on the
     # basename and check the directory separately.
     missing = sorted({p.name for p in paths if not _names(readme, p.name)})

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -15,6 +15,7 @@ import yaml
 from anthropic import Anthropic
 
 from extract_pages import extract_pdf
+from extraction_result import ExtractionResult
 import web_source
 import enrich
 
@@ -535,16 +536,20 @@ excerpt's text won't (e.g. an embedded Author field):
                 config['model'] - for pdf-in/careful/ sources (see process_batch).
 
         Returns:
-            str: BibLaTeX entry or error message
+            ExtractionResult: the entry text plus the review state that
+            belongs to it (source label, needs_color, amber reason, field
+            provenance), or one carrying `error`. The state used to travel as
+            `%` markers prepended to the text and parsed back out by
+            save_entry(); see extraction_result.py for why it no longer does.
         """
         path = Path(path)
 
         if not path.exists():
-            return f"Error: File not found: {path}"
+            return ExtractionResult(error=f"Error: File not found: {path}")
 
         extractor = EXTRACTORS.get(path.suffix.lower())
         if extractor is None:
-            return f"Error: Unsupported file type: {path.name}"
+            return ExtractionResult(error=f"Error: Unsupported file type: {path.name}")
 
         if batch_info:
             i, total = batch_info
@@ -575,7 +580,7 @@ excerpt's text won't (e.g. an embedded Author field):
         content = extractor(path, **kwargs)
 
         if isinstance(content, str):  # error message
-            return content
+            return ExtractionResult(error=content)
 
         # Load context files
         self._log("   Loading context...", 'info')
@@ -612,8 +617,9 @@ excerpt's text won't (e.g. an embedded Author field):
                 self._log(f"   Stripped disallowed field(s): {', '.join(stripped)}", 'warning')
 
             needs_color = False
+            field_sources = None
             if self.config.get('enrich_missing_fields', True):
-                bibtex_entry = self.enrich_entry(bibtex_entry, content)
+                bibtex_entry, field_sources = self.enrich_entry(bibtex_entry, content)
                 bibtex_entry, needs_color = self.verify_and_flag_recollection(bibtex_entry, content)
 
             # content.amber is web_source.py's plausibility check flagging a
@@ -622,27 +628,29 @@ excerpt's text won't (e.g. an embedded Author field):
             # just worth a glance. Folded into the same needs_color signal a
             # recollection-audit failure uses, so it reaches BibDesk's review
             # color by exactly the path a PDF's review state does. The
-            # additional "% AMBER: ..." comment carries the same flag on the
-            # other branch, where entries are appended as text and no color
-            # is possible; each survives where the other cannot (see
-            # save_entry).
+            # "% AMBER: ..." comment save_entry writes from amber_reason
+            # carries the same flag on the other branch, where entries are
+            # appended as text and no color is possible; each survives where
+            # the other cannot.
+            amber_reason = None
             if content.amber:
                 needs_color = True
+                amber_reason = content.amber_reason
                 self._log(f"   ⚠️  Thin/sparse source ({content.amber_reason}) - flagging for review", 'warning')
-                bibtex_entry = f"% AMBER: {content.amber_reason}\n" + bibtex_entry
-
-            if needs_color:
-                bibtex_entry = "% NEEDS_COLOR_FLAG\n" + bibtex_entry
-
-            bibtex_entry = f"% Source: {content.label} ({content.url or path.name})\n" + bibtex_entry
 
             self._log("   Validating entry...", 'info')
             self._log("   ✓ Complete", 'success')
 
-            return bibtex_entry
+            return ExtractionResult(
+                entry=bibtex_entry,
+                source_label=f"{content.label} ({content.url or path.name})",
+                needs_color=needs_color,
+                amber_reason=amber_reason,
+                field_sources=field_sources,
+            )
 
         except Exception as e:
-            return f"Error: {e}"
+            return ExtractionResult(error=f"Error: {e}")
 
     def _build_enrich_prompt(self, entry, found_fields):
         """Build a prompt asking Claude to merge externally-sourced fields
@@ -680,14 +688,19 @@ commentary."""
             entry_text: The BibLaTeX entry produced so far
             content: The SourceContent (PDF or webpage) the entry was drawn from
 
-        Returns the (possibly unchanged) entry text.
+        Returns (entry_text, field_sources): the possibly-unchanged entry, and
+        a one-line per-field provenance summary, or None when nothing was
+        enriched. The summary used to be prepended to the returned text as a
+        "% Sources -- ..." comment and sliced back off by save_entry(); it is
+        now returned beside the text and rendered once, at the point of
+        writing. See extraction_result.py.
         """
         entry_type = enrich.get_entry_type(entry_text)
         fields = enrich.parse_bibtex_fields(entry_text)
         required, desired = enrich.missing_fields(entry_type, fields)
         if not required and not desired:
             self._log(f"   Source: {content.label} (all fields present, no enrichment needed)", 'info')
-            return entry_text
+            return entry_text, None
 
         title = enrich.strip_latex(fields.get('title', ''))
         found, field_sources = enrich.gather_enrichment(
@@ -697,7 +710,7 @@ commentary."""
         )
         if not found:
             self._log(f"   ⚠️  Missing fields not found via CrossRef/Scholar: {', '.join(required + desired)}", 'warning')
-            return entry_text
+            return entry_text, None
 
         by_source = {}
         for field, source in field_sources.items():
@@ -716,22 +729,22 @@ commentary."""
             merged = self.clean_bibtex(response_text(message))
             valid, _ = self.validate_braces(merged)
             if not valid:
-                return entry_text
+                return entry_text, None
         except Exception as e:
             self._log(f"   ⚠️  Enrichment merge failed: {e}", 'warning')
-            return entry_text
+            return entry_text, None
 
-        # Record per-field provenance as a persistent comment so it survives
-        # past this run's log, rather than only being visible in the console/window.
+        # Per-field provenance, returned so save_entry can persist it as a
+        # comment - it should survive past this run's log rather than being
+        # visible only in the console/window.
         source_fields = sorted(f for f, v in fields.items() if v)
         source_lines = []
         if source_fields:
             source_lines.append(f"{content.label}: {', '.join(source_fields)}")
         for src, fs in by_source.items():
             source_lines.append(f"{src}: {', '.join(sorted(fs))}")
-        comment = f"% Sources -- {'; '.join(source_lines)}\n"
 
-        return comment + merged
+        return merged, '; '.join(source_lines)
 
     def _build_audit_prompt(self, entry, content):
         """Build a prompt asking Claude to self-audit which of its own field
@@ -1223,69 +1236,30 @@ end tell'''
             f.write("\n\n")
         self._log(f"   ✗ Failed entry saved to {failed_path}", 'error')
 
-    def save_entry(self, bibtex_entry, pdf_path):
-        """Validate, enrich with a BibDesk bookmark, and append to the main bib file."""
+    def save_entry(self, result, pdf_path):
+        """Validate, enrich with a BibDesk bookmark, and append to the main bib file.
+
+        `result` is the ExtractionResult extract_bibtex() returned. Its review
+        state arrives as attributes; it is no longer prepended to the entry
+        text as `%` markers for this method to match positionally and slice
+        off. That protocol is what made the amber-colouring regression both
+        possible and silent - one marker's regex could never match, and
+        because re.match anchors at position 0, every matcher below it then
+        failed too, for every entry and every source type, reporting nothing.
+        See extraction_result.py and issues #17/#18.
+
+        The `%` comments still reach the saved file, rendered here from the
+        result rather than parsed out of it.
+        """
         pdf_path = Path(pdf_path)
 
-        # extract_bibtex() prepends a "% Source: ..." comment recording which
-        # kind of source (PDF/webpage) and locator produced this entry;
-        # clean_bibtex() strips anything before the first '@', so pull it out
-        # first and re-attach it once cleaning is done (outermost marker -
-        # see the prepend order in extract_bibtex).
-        #
-        # Until fixed here, this pattern's \b sat right after the literal
-        # ':' (`Source:\b`) - impossible, since neither side of that
-        # position is a word character - so it never matched anything.
-        # Because % Source: is always the outermost/first line and re.match
-        # anchors at position 0, that didn't just drop this comment: with
-        # bibtex_entry left unstripped, EVERY marker regex below it also
-        # failed to match against the unrelated text still sitting at
-        # position 0, for every entry this method ever saved - PDF or
-        # .webloc alike. needs_color could never become True by this path
-        # before this fix, so BibDesk's amber coloring (UNVERIFIED_COLOR)
-        # was inert from the day it was introduced, not merely blind to
-        # .webloc sources as the comments below (written after this fix)
-        # describe for the design going forward.
-        source_comment = ''
-        marker_match = re.match(r'(%\s*Source\b:[^\n]*\n)', bibtex_entry)
-        if marker_match:
-            source_comment = marker_match.group(1)
-            bibtex_entry = bibtex_entry[marker_match.end():]
+        needs_color = result.needs_color
+        # Outermost first: Source, then AMBER, then Sources. clean_bibtex()
+        # discards everything before the first '@', so these are attached
+        # after cleaning, not before.
+        comment_block = ''.join(line + "\n" for line in result.comment_lines())
 
-        # verify_and_flag_recollection() prepends a bare "% NEEDS_COLOR_FLAG"
-        # marker when a recollection-based field couldn't be confirmed or
-        # refuted via CrossRef/Scholar. Unlike the Sources comment below, this
-        # one is discarded (not re-attached) - it only decides whether to
-        # color the BibDesk publication, so it shouldn't persist in the .bib text.
-        needs_color = False
-        marker_match = re.match(r'(%\s*NEEDS_COLOR_FLAG\s*\n)', bibtex_entry)
-        if marker_match:
-            needs_color = True
-            bibtex_entry = bibtex_entry[marker_match.end():]
-
-        # extract_bibtex() prepends a "% AMBER: ..." comment when
-        # content.amber is set (web_source.py's plausibility check: a
-        # genuine but thin/sparse source). Unlike NEEDS_COLOR_FLAG, this one
-        # IS re-attached below: a .webloc source is never fileable (see the
-        # is_fileable_source check further down), so it never reaches
-        # BibDesk's own color, and this comment is the only place the flag
-        # survives into the saved .bib text.
-        amber_comment = ''
-        marker_match = re.match(r'(%\s*AMBER\b:[^\n]*\n)', bibtex_entry)
-        if marker_match:
-            amber_comment = marker_match.group(1)
-            bibtex_entry = bibtex_entry[marker_match.end():]
-
-        # enrich_entry() prepends a "% Sources -- ..." comment recording field
-        # provenance; clean_bibtex() strips anything before the first '@', so
-        # pull the comment out first and re-attach it once cleaning is done.
-        sources_comment = ''
-        marker_match = re.match(r'(%\s*Sources\b[^\n]*\n)', bibtex_entry)
-        if marker_match:
-            sources_comment = marker_match.group(1)
-            bibtex_entry = bibtex_entry[marker_match.end():]
-
-        entry = self.clean_bibtex(bibtex_entry)
+        entry = self.clean_bibtex(result.entry)
 
         # Reject responses that are not BibTeX entries
         if not entry.lstrip().startswith('@'):
@@ -1301,12 +1275,7 @@ end tell'''
             self.notify_failure(pdf_path.name, error_msg)
             return False
 
-        if sources_comment:
-            entry = sources_comment + entry
-        if amber_comment:
-            entry = amber_comment + entry
-        if source_comment:
-            entry = source_comment + entry
+        entry = comment_block + entry
 
         # Flag entries still missing critical fields after enrichment (does not block saving)
         entry_type = enrich.get_entry_type(entry)
@@ -1355,7 +1324,7 @@ end tell'''
         if needs_color:
             self._log("   ⚠️  Unverified field(s) or a thin source - color flag needs "
                       "autofile_bibdesk to apply"
-                      + (" (see the % AMBER comment in the saved entry)" if amber_comment else ""),
+                      + (" (see the % AMBER comment in the saved entry)" if result.amber_reason else ""),
                       'warning')
 
         output_path = Path(self.config['main_bib_file']).expanduser()
@@ -1471,15 +1440,15 @@ end tell'''
             self.notify_progress(f"[{i}/{total}] {pdf_path.name}", subtitle="Extracting bibliography")
 
             # Extract bibliography
-            bibtex_entry = self.extract_bibtex(pdf_path, batch_info=(i, total), model_override=model_for_file)
+            result = self.extract_bibtex(pdf_path, batch_info=(i, total), model_override=model_for_file)
 
-            if bibtex_entry.startswith("Error:"):
-                self._log(f"   ✗ {bibtex_entry}", 'error')
-                results['failed'].append((pdf_path.name, bibtex_entry))
+            if result.failed:
+                self._log(f"   ✗ {result.error}", 'error')
+                results['failed'].append((pdf_path.name, result.error))
                 continue
 
             # Save entry
-            saved = self.save_entry(bibtex_entry, pdf_path)
+            saved = self.save_entry(result, pdf_path)
             if not saved:
                 results['failed'].append((pdf_path.name, "save failed"))
                 continue
@@ -1669,15 +1638,15 @@ def main():
         for pdf_path in pdf_files:
             agent._log(f"\n📄 Processing: {pdf_path.name}", 'info')
 
-            bibtex_entry = agent.extract_bibtex(pdf_path)
+            result = agent.extract_bibtex(pdf_path)
 
-            if bibtex_entry.startswith("Error:"):
-                print(bibtex_entry, file=sys.stderr)
+            if result.failed:
+                print(result.error, file=sys.stderr)
                 continue
 
-            clean_entry = agent.clean_bibtex(bibtex_entry)
+            clean_entry = agent.clean_bibtex(result.entry)
             if not args.no_save:
-                saved = agent.save_entry(bibtex_entry, pdf_path)
+                saved = agent.save_entry(result, pdf_path)
                 if not saved:
                     print(f"Error: failed to save entry for {pdf_path.name}", file=sys.stderr)
                     sys.exit(1)

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -304,7 +304,7 @@ class BiblioAgent:
                 "fields to omit, when Url/Urldate may appear, title case, name format, "
                 "Title/Subtitle splitting. On a style question the guidelines win; on a "
                 "what-does-the-package-support question the corpora win.\n\n"
-                "<reference_template> covers only 20 of the ~40 entry types and is NOT an "
+                "<reference_template> covers 12 of the ~40 entry types and is NOT an "
                 "allowlist: choose whichever type genuinely fits, including ones it omits "
                 "(@Letter, @CustomC, @Audio, @Artwork, @Manual, @Booklet, @Bookinbook, "
                 "@Dataset, @Standard, @Performance, @Patent, @Image, the @Mv* types, and "
@@ -432,10 +432,10 @@ excerpt's text won't (e.g. an embedded Author field):
    @Inproceedings vs @Incollection above - a named conference/proceedings
    title, not just an edited-volume structure).
    For unpublished academic work, distinguish @Thesis (a dissertation
-   submitted to a degree-granting institution - Type = {\bibstring{phdthesis}}
-   or {\bibstring{mastersthesis}}, Institution = the institution), @Report (an
+   submitted to a degree-granting institution - Type = {\\bibstring{phdthesis}}
+   or {\\bibstring{mastersthesis}}, Institution = the institution), @Report (an
    institutional/technical/research report NOT submitted for a degree - Type
-   = {\bibstring{techreport}} or a similarly descriptive bibstring), and
+   = {\\bibstring{techreport}} or a similarly descriptive bibstring), and
    @Unpublished (anything else unpublished, including a conference paper with
    no proceedings volume - see the guidelines for the required Note field).
    For a review of another work (rather than a standalone article), use

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -432,9 +432,9 @@ excerpt's text won't (e.g. an embedded Author field):
      because a chapter's opening pages tend to cite the literature heavily.
      If nothing in the given text presents itself as the container, OMIT
      Booktitle rather than supplying a plausible one, exactly as instructed
-     for Location at step 5. An @Incollection or @Inproceedings that is
-     missing its Booktitle is reported as incomplete and can be finished by
-     hand; one carrying a confident wrong Booktitle is not reported at all.
+     for Location at step 5. A field left empty is a gap someone can see and
+     fill; a field filled with the wrong work reads as evidence and will not
+     be questioned.
    - Exception: if the piece is UNTITLED supplemental material (a generic
      preface, foreword, introduction, or index with no title of its own,
      written by someone other than the book's main author) rather than a

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -460,10 +460,23 @@ excerpt's text won't (e.g. an embedded Author field):
    clause, is incomplete. Where one review covers several works, each keeps
    its own \\bibstring{by} clause in both fields.
 
-   Title holds the reviewed work's own title and author and nothing else.
-   Volume/series/translator/editor detail printed alongside it on the review's
-   first page ("Vol. III of ...", "translated and edited by ...") belongs to
-   the volume being reviewed, not to this entry's Title - leave it out.
+   Title holds the reviewed work's own title and author and nothing else. The
+   publishing apparatus printed alongside them on the review's first page -
+   volume or series position ("Vol. III of ..."), translator and editor
+   credits ("translated and edited by ..."), publisher, place, price - belongs
+   to the volume under review, not to this entry's Title. Leave it out.
+
+   That is a rule about which FACTS Title carries. It is not licence to
+   simplify how the title and author are written: inside Title and Shorttitle
+   alike, encode them exactly as the guidelines require of any other entry.
+   In particular, and these are the two that go wrong -
+   - a reviewed title, or the part of one, in a language other than the
+     review's own still takes its \\foreignlanguage{<language>}{...} wrapper,
+     inside \\mkbibemph; and
+   - a forename followed by an initial still takes the non-breaking tie:
+     \\bibstring{by} Lee~A. Rothfarb, never "Lee A. Rothfarb".
+   The Kivy example above is short only because that title is English and that
+   author has no initial; it is not a model for stripping either.
 
    Do not use a generic @Article for a review. Conversely, an article that
    merely discusses, cites or responds to other publications is NOT a review:

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -14,6 +14,7 @@ from datetime import datetime
 import yaml
 from anthropic import Anthropic
 
+import extract_pages
 from extract_pages import extract_pdf
 import web_source
 import enrich
@@ -522,6 +523,8 @@ excerpt's text won't (e.g. an embedded Author field):
             language_prompt_fn=language_prompt_fn,
             min_words_threshold=self.config.get('ocr_threshold', 100),
             ocr_timeout=self.config.get('ocr_timeout', 180),
+            thin_yield_words=self.config.get(
+                'thin_yield_threshold', extract_pages.DEFAULT_THIN_YIELD_WORDS),
         )
 
     def extract_bibtex(self, path, batch_info=None, model_override=None):

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -439,10 +439,36 @@ excerpt's text won't (e.g. an embedded Author field):
    @Unpublished (anything else unpublished, including a conference paper with
    no proceedings volume - see the guidelines for the required Note field).
    For a review of another work (rather than a standalone article), use
-   @Review and encode the reviewed work's title/author directly into Title
-   per the convention in the guidelines and demonstrated in
-   biblio-template.bib's Dunsby1997 entry - do not use a generic @Article for
-   a review.
+   @Review. The reviewed work is encoded directly into Title, and a
+   compressed form of it into Shorttitle, using exactly this construction:
+
+     Title = {\\bibstring{reviewof} \\mkbibemph{Authenticities: Philosophical
+       Reflections on Musical Performance}, \\bibstring{by} Peter Kivy},
+     Shorttitle = {\\bibstring{reviewof} \\mkbibemph{Authenticities},
+       \\bibstring{by} Kivy},
+
+   The name after \\bibstring{by} is the author of the work BEING REVIEWED. It
+   is never the reviewer, who is this entry's own Author and appears nowhere
+   in Title or Shorttitle - identify the two people separately.
+
+   Shorttitle compresses in two ways at once, and BOTH are required:
+   - the reviewed title is cut back to its first few words (at the colon,
+     where there is one), and
+   - the reviewed author is reduced to a bare surname, no forenames or
+     initials.
+   A Shorttitle that stops after the reviewed title, with no \\bibstring{by}
+   clause, is incomplete. Where one review covers several works, each keeps
+   its own \\bibstring{by} clause in both fields.
+
+   Title holds the reviewed work's own title and author and nothing else.
+   Volume/series/translator/editor detail printed alongside it on the review's
+   first page ("Vol. III of ...", "translated and edited by ...") belongs to
+   the volume being reviewed, not to this entry's Title - leave it out.
+
+   Do not use a generic @Article for a review. Conversely, an article that
+   merely discusses, cites or responds to other publications is NOT a review:
+   @Review is for a piece whose subject is one or more named works under
+   notice, normally announced as such on its own first page.
 2. Extract all relevant bibliographic fields
 3. Split a colon-separated title into Title (before the colon) and Subtitle
    (after it), omitting the colon itself - biblatex-chicago supplies it. Same

--- a/src/biblio_agent.py
+++ b/src/biblio_agent.py
@@ -399,6 +399,15 @@ excerpt's text won't (e.g. an embedded Author field):
    - Use @Incollection if it's one chapter of an edited volume where
      different chapters have different authors (an Editor field for the
      volume, distinct from this chapter's Author).
+     An editor's name on the title page is NOT what decides this. Plenty of
+     single-author volumes are edited by someone else - a selection from one
+     writer's work, a collected-essays volume, a critical edition - and those
+     are @Inbook WITH an Editor field, not @Incollection. The question is
+     always who wrote the OTHER contributions: several hands means
+     @Incollection, one hand throughout means @Inbook however prominent the
+     editor is. A title page reading "<Author>, <Title>, edited by <Editor>",
+     or a series list on the endpapers naming only that one author's books,
+     both point to @Inbook.
    - Use @Inproceedings if it's one paper within a conference proceedings
      volume (Booktitle = the proceedings volume, Booktitleaddon = the
      conference name/location if given). The discriminator against
@@ -413,6 +422,19 @@ excerpt's text won't (e.g. an embedded Author field):
      visible in a running header, distinct from the piece's own heading) -
      do NOT use the container's title as the entry's Title when the excerpt
      is clearly one part of a larger work.
+   - Booktitle, Booktitleaddon, Eventtitle, Series and the volume's Editor
+     must come from the CONTAINER presenting itself as such: a title page, a
+     running header or footer, a half-title, a copyright page, a "Proceedings
+     of ..." or series statement. A book, journal or conference NAMED IN THE
+     BODY TEXT - discussed, quoted, cited, or sitting in a reference list -
+     is a work this piece talks about, not the volume it appears in, and must
+     never be used for these fields. The two are easy to confuse precisely
+     because a chapter's opening pages tend to cite the literature heavily.
+     If nothing in the given text presents itself as the container, OMIT
+     Booktitle rather than supplying a plausible one, exactly as instructed
+     for Location at step 5. An @Incollection or @Inproceedings that is
+     missing its Booktitle is reported as incomplete and can be finished by
+     hand; one carrying a confident wrong Booktitle is not reported at all.
    - Exception: if the piece is UNTITLED supplemental material (a generic
      preface, foreword, introduction, or index with no title of its own,
      written by someone other than the book's main author) rather than a

--- a/src/extract_pages.py
+++ b/src/extract_pages.py
@@ -16,6 +16,15 @@ from typing import Optional
 from pypdf import PdfReader, PdfWriter
 
 
+# Words a whole PDF has to yield before its extraction is taken at face
+# value. Motte2004, the source that prompted this, gave 232 across all its
+# pages where comparable sources in the evaluation sample gave 1,000-3,100.
+# Deliberately well above ocr_threshold (100), which decides whether OCR is
+# attempted at all: a floor set at or below that could never fire, since
+# anything under it has already been through OCR by the time this is checked.
+DEFAULT_THIN_YIELD_WORDS = 400
+
+
 @dataclass
 class SourceContent:
     """Normalized shape produced by every source extractor (PDF, webloc, ...).
@@ -28,10 +37,13 @@ class SourceContent:
     metadata: dict = field(default_factory=dict)
     label: str = "PDF"          # human-readable source kind, used once in build_prompt
     url: Optional[str] = None   # set only when the source has a canonical access URL
-    # Set by web_source.py's plausibility check: the content genuinely came
-    # from the requested URL but is thin or sparse (missing metadata, short
-    # body) - not wrong, just worth a human glance. biblio_agent.py folds
-    # this into the existing "needs_color" (BibDesk amber) mechanism.
+    # The content is genuine but thin - not wrong, just worth a human glance.
+    # Set by web_source.py's plausibility check (a page that came from the
+    # requested URL but carries little metadata or a short body) and by
+    # extract_pdf() (a PDF that yielded very few words across all its pages,
+    # whether or not OCR ran). biblio_agent.py folds either into the existing
+    # "needs_color" (BibDesk amber) mechanism, so the two are indistinguishable
+    # downstream - which is the point: the reader's question is the same one.
     amber: bool = False
     amber_reason: Optional[str] = None
 
@@ -276,7 +288,12 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
         ocr_timeout: Seconds to allow ocrmypdf before giving up
 
     Returns:
-        str: Extracted text with section markers
+        (str, int): the extracted text with section markers, and the total
+        word count the PDF yielded across all its pages - after OCR, where OCR
+        ran. The count is returned rather than left to be re-derived from the
+        text, which is only an excerpt of it, and rather than parsed back out
+        of the "--- BEGINNING (n words) ---" headers, which would make a
+        display string load-bearing. On an error the pair is (error, 0).
     """
     pdf_path = Path(pdf_path)
 
@@ -284,7 +301,7 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
     result, num_pages = extract_all_text(pdf_path)
 
     if isinstance(result, str) and result.startswith("Error:"):
-        return result
+        return result, 0
 
     page_texts = result
     full_text = "\n\n".join(page_texts)
@@ -342,7 +359,7 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
             if not quiet:
                 print(f"✓ OCR successful ({total_words} words)", file=sys.stderr)
         else:
-            return f"Error: {ocr_result}"
+            return f"Error: {ocr_result}", 0
 
     # Determine beginning section: max(first page, min_first_words)
     first_page_text = page_texts[0] if page_texts else ""
@@ -359,7 +376,7 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
 
     # Short documents: return everything
     if total_words <= first_count + last_words:
-        return f"--- FULL TEXT ({total_words} words) ---\n{full_text.strip()}"
+        return f"--- FULL TEXT ({total_words} words) ---\n{full_text.strip()}", total_words
 
     # Extract last M words (snap to sentence)
     last_section = snap_to_sentence_end(full_text, last_words, from_end=True)
@@ -380,10 +397,10 @@ def extract_content(pdf_path, min_first_words=450, last_words=150, min_words_thr
         )
         output.append(headers_footers)
 
-    return "\n".join(output)
+    return "\n".join(output), total_words
 
 
-def extract_pdf(pdf_path, **opts):
+def extract_pdf(pdf_path, thin_yield_words=DEFAULT_THIN_YIELD_WORDS, **opts):
     """
     Extract a PDF's bibliographic content as a SourceContent.
 
@@ -393,13 +410,40 @@ def extract_pdf(pdf_path, **opts):
     extract_content() (min_first_words, last_words, min_words_threshold,
     quiet, language_prompt_fn, ocr_timeout).
 
+    Args:
+        thin_yield_words: Below this many words for the whole PDF, the result
+            is marked amber. 0 disables the check.
+
     Returns:
         SourceContent on success, or a string starting with "Error:" on failure.
     """
-    text = extract_content(pdf_path, **opts)
+    text, total_words = extract_content(pdf_path, **opts)
     if isinstance(text, str) and text.startswith("Error:"):
         return text
-    return SourceContent(text=text, metadata=extract_pdf_metadata(pdf_path), label="PDF")
+
+    # A PDF that completes extraction having yielded almost nothing is the
+    # same failure shape as a bot-challenge page that answers HTTP 200: the
+    # process succeeded and the content did not. OCR finishing is not OCR
+    # working - a scan whose text layer holds only whitespace comes back
+    # exit 0 with a handful of words, and the entry built from it looks
+    # exactly as confident as one built from three thousand.
+    #
+    # It rides the amber carrier a thin webpage already uses rather than
+    # introducing a signal of its own: identical treatment (BibDesk's review
+    # colour, and a "% AMBER: ..." comment where colour is impossible) for
+    # what is identically a source worth a human glance rather than a
+    # failure. Some sources genuinely carry no bibliographic text - a
+    # photocopied chapter with no title page - and those must still produce
+    # an entry.
+    amber = amber_reason = None
+    if thin_yield_words and total_words < thin_yield_words:
+        amber = True
+        amber_reason = (f"thin extraction: {total_words} words from the whole PDF "
+                        f"(under {thin_yield_words}) - the text may not carry the "
+                        f"work's bibliographic data at all")
+
+    return SourceContent(text=text, metadata=extract_pdf_metadata(pdf_path), label="PDF",
+                         amber=bool(amber), amber_reason=amber_reason)
 
 
 if __name__ == "__main__":
@@ -407,5 +451,6 @@ if __name__ == "__main__":
         print("Usage: python extract_pages.py <pdf_file>", file=sys.stderr)
         sys.exit(1)
 
-    result = extract_content(sys.argv[1])
-    print(result)
+    text, total_words = extract_content(sys.argv[1])
+    print(text)
+    print(f"\n--- TOTAL YIELD: {total_words} words ---", file=sys.stderr)

--- a/src/extraction_result.py
+++ b/src/extraction_result.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""
+What extract_bibtex() hands to save_entry(): the entry text, and the review
+state that belongs to it.
+
+Before this existed the two functions communicated through `%` comment markers
+prepended to the entry text, which save_entry() recovered by matching each one
+positionally with an anchored re.match and slicing it off. Three properties of
+that arrangement all bit within a month of each other:
+
+- Order was load-bearing and unchecked. Adding a marker meant prepending it in
+  one function and inserting its matcher at exactly the right point in the
+  other, in two places that named each other only in comments.
+- A failed match was silent, and cascaded. `% Source:` arrived with an
+  extraction regex that could never match (`Source:\\b` - no word boundary can
+  exist between ':' and a space), and because re.match anchors at 0 and that
+  marker was outermost, every matcher below it then ran against a string still
+  starting `% Source:` and failed too. BibDesk's amber colouring stopped
+  working for every entry and every source type, from 2026-07-30 until it was
+  found. Nothing anywhere reported a problem. See issues #17 and #18.
+- The carrier was lossy, and differed by branch. Under autofile_bibdesk the
+  importer re-serializes each entry and discards every `%` comment, so
+  comment-carried state survived only on the plain-text-append branch and
+  colour-carried state only on the BibDesk branch.
+
+The markers remain as an OUTPUT format - they are how provenance reaches the
+saved .bib text, and they are worth having there. They are no longer an
+interchange format between two functions.
+
+This module deliberately imports nothing beyond the standard library, so the
+evaluation harness can construct a result without pulling in the Anthropic
+client or pypdf. A stub that returns the shape the caller expects rather than
+the shape the system emits is how the last round of testing missed a live
+fault; sharing the real class is what stops that here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+
+@dataclass
+class ExtractionResult:
+    """One source's extraction: the entry, plus what is known about it.
+
+    `error` set means extraction did not produce an entry, and `entry` is
+    meaningless. Every other field describes an entry that exists.
+    """
+
+    entry: str = ''
+
+    # Extraction failed. Carries the human-readable reason, already prefixed
+    # "Error: " so it reads the same wherever it is printed.
+    error: Optional[str] = None
+
+    # Which kind of source and which locator produced this - "PDF (paper.pdf)",
+    # "webpage (https://...)". Written to the saved text as "% Source: ...".
+    source_label: Optional[str] = None
+
+    # A field could not be confirmed or refuted against CrossRef/Scholar, or
+    # the source was thin. Becomes BibDesk's review colour; never written to
+    # the text, because the colour is where it belongs.
+    needs_color: bool = False
+
+    # web_source.py's plausibility check found the source genuine but thin or
+    # sparse. Written as "% AMBER: <reason>", which is the only carrier that
+    # survives on the plain-text-append branch, where no colour is possible.
+    amber_reason: Optional[str] = None
+
+    # Per-field provenance from enrichment - "CrossRef: volume, pages".
+    # Written as "% Sources -- ...".
+    field_sources: Optional[str] = None
+
+    @property
+    def failed(self) -> bool:
+        return self.error is not None
+
+    def comment_lines(self) -> list:
+        """The `%` comments this result contributes, outermost first.
+
+        `needs_color` is absent by design: it is state about the entry, not a
+        fact about it, and it reaches the reader as a colour. An INCOMPLETE
+        comment is not here either - that is determined at save time, from the
+        finished entry, not by extraction.
+        """
+        lines = []
+        if self.source_label:
+            lines.append(f"% Source: {self.source_label}")
+        if self.amber_reason:
+            lines.append(f"% AMBER: {self.amber_reason}")
+        if self.field_sources:
+            lines.append(f"% Sources -- {self.field_sources}")
+        return lines


### PR DESCRIPTION
The merged state of the six PRs, with the two documentation conflicts resolved by
hand, plus the record of the full 61-entry run made against it.

**Not for merging on its own.** It exists so the run has a reviewable object and so
the conflict resolutions are visible before you merge the branches individually.
Merge the six in their stated order and this becomes redundant.

## What is here beyond the six branches

- `dev/eval/sample/README.md` — both `container_source` (#26) and
  `insufficient_source` (#28) sections, kept whole.
- `README.md` — #27's rewritten `test_biblio_agent_markers.py` paragraph, #28's new
  `test_extract_pages.py` paragraph, and both `src/` tree lines.
- `dev/eval/test_eval.py` — both new imports.
- `dev/eval/baselines/2026-08-29-integration.md` — the run record.

## Verified on the merged tree

- All four suites: `test_eval.py` (17), `test_biblio_agent_markers.py` (8),
  `test_web_source.py` (40), `test_extract_pages.py` (7). `test_setup.py` fully
  green, including `✓ all 39 tracked files listed`.
- **The combined prompt renders with no control characters** — three branches edited
  the same string literal, which is the thing most likely to have broken silently.
- Every clause from each branch is present in the rendered prompt (checked by
  substring probe, not by reading the diff).

## Headline numbers

Entry type **50/61 → 51/61**. Field verdicts **exact 249 → 240, different 117 →
117, missing 94 → 103, spurious 83 → 67**.

The full attribution, per entry, is in the baseline document.

Refs #14, #15, #16, #18, #21, #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjmVC9CiFbyxSjHeKfxZY4

---

## Correction to the field figures above

`expected.bib` changed twice on 2026-08-29 — `4dff992` (Menke2004's author) and
`7155812` (Arndt2014's title, Cavell1969a's pages) — and the field table published
in `2026-08-29.md` predates both. Comparing this run against that table would have
been comparing two ground truths.

Re-scored the baseline run's own saved output against `expected.bib` as it now
stands, so both sides face one ground truth. **The delta is unchanged:
exact 249 → 240, different 117 → 117, missing 94 → 103, spurious 83 → 67.** The
totals coincide with the published ones by accident — `author` moves 33 → 34 and
`title` 37 → 36 under the corrected file, and they offset.

Two issues this session filed are now closed as **resolved by the maintainer's
correction**, not as mistaken: #24 (real, and fixed in `7155812` mid-session — I
later checked an already-fixed file and wrongly retracted it) and #20 (real, though
the value I proposed, `180-212`, was wrong; it is `180-201`).
